### PR TITLE
Link to plural rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This isn't _super_ obvious in Loca Studio:
 
 <img width="410" alt="Screenshot 2024-05-10 at 8 24 59 PM" src="https://github.com/cliss/callsheet-localizations/assets/282460/af01548a-6f2a-4b2d-aa5d-3139ba935370">
 
-Note that the `Source` column kind of hints at what's going on here, but the `ID` column shows `plural-one` for the singular version and `plural-other` for the plural version. Fill each in as appropriate, please.
+Note that the `Source` column kind of hints at what's going on here, but the `ID` column shows `plural.one` for the singular version and `plural.other` for the plural version. Fill each in as appropriate, please.
 
 [Language Plural Rules](https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This isn't _super_ obvious in Loca Studio:
 
 Note that the `Source` column kind of hints at what's going on here, but the `ID` column shows `plural-one` for the singular version and `plural-other` for the plural version. Fill each in as appropriate, please.
 
+[Language Plural Rules](https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html)
+
 ## Submission Flow
 
 I've never done this before, so I'm working this out as we go, as well. But here's my vision for how I hope this will work:


### PR DESCRIPTION
A link to the Unicode doc might be handy when [translating](https://github.com/cliss/callsheet-localizations/commit/50f7c7df76ac3cddc6f4ce9a73867570a57986d1) to languages with several plural forms

Also, seems like there's a typo in README — IDs in `.xliff`s use periods in `plural.XYZ` tags, not dashes