### PR TITLE
Add Norwegian (nb-NO) localization

### DIFF
--- a/AppStore/Norwegian/Description.iOS.txt
+++ b/AppStore/Norwegian/Description.iOS.txt
@@ -1,0 +1,28 @@
+Har du noen gang lurt på "hvem er den skuespilleren?", eller kanskje "når ble denne filmen utgitt?", eller "hva var tittelen på den episoden av den serien jeg elsker"? Kanskje du er en filmentusiast og lurer på "hvor gammel var denne personen da denne filmen ble utgitt"?
+
+Har du ønsket å finne svarene på disse spørsmålene *uten* å bli bedt om å logge inn hvert femte sekund? Uten reklamer og uten videoer som spiller av automatisk? Uten å måtte stole på et multinasjonalt konglomerat som prøver å selge deg ting?
+
+Da vil du elske Callsheet.
+
+Callsheet er den beste måten å raskt finne informasjon om medvirkende og besetning i TV og filmer. Den respekterer tiden din, prøver ikke å selge deg ting du ikke trenger, og er designet for å svare raskt og enkelt på spørsmålene dine.
+
+Callsheet har også noen nyskapende funksjoner som din forrige favorittdatabase-app ikke har:
+
+• Forhindre spoilere når du ser på TV-serier ved å valgfritt skjule karakternavn, episodeteller, episodetitler eller episodethumbnails. Ikke la deg selv bli spoilet om en karakters hemmelige identitet, eller at de plutselig forlater showet, ved å skjule denne informasjonen.
+• Rask tilgang til trivia, Wikipedia, aldersanbefalinger og hvor du kan se (levert av JustWatch).
+• Fest TV-serier, filmer eller personer for rask tilgang.
+• Finn ting du har søkt etter tidligere ved å bruke nylige søk og søkeloggen.
+• Se enkelt alderen på de medvirkende *når en film ble utgitt* sammen med rollelisten.
+• Du kan enkelt se alderen til en person for hver oppføring i filmografien deres.
+• Du kan lett se høyden til skuespillere (når informasjonen er tilgjengelig).
+• Støtte for mørk modus.
+• Støtte for VoiceOver.
+• Alternative app-ikoner for abonnenter.
+• Automatisk integrasjon uten innlogging med den fantastiske Channels-appen.
+• Eksperimentell integrasjon med Plex uten innlogging.
+
+Callsheet er skrevet av én person, som VIRKELIG bryr seg om å respektere tiden din. Callsheet er designet for å la deg enkelt finne det du trenger uten problemer, og deretter komme tilbake til filmen eller serien du virkelig bryr deg om. Ingen distraksjoner og ingen forespørsler om å logge inn.
+
+Callsheet tilbyr 20 gratissøk, og krever deretter et abonnement. Abonnementene kommer alle med en 1-ukes gratis prøveperiode. De støtter Familiedeling.
+
+Prøv Callsheet. Du vil ikke tro hvor mye bedre den er enn appen du brukte tidligere.

--- a/AppStore/Norwegian/Description.visionOS.txt
+++ b/AppStore/Norwegian/Description.visionOS.txt
@@ -1,0 +1,28 @@
+Har du noen gang lurt på "hvem er den skuespilleren?", eller kanskje "når ble denne filmen utgitt?", eller "hva var tittelen på den episoden av den serien jeg elsker"? Kanskje du er en filmentusiast og lurer på "hvor gammel var denne personen da denne filmen ble utgitt"?
+
+Har du ønsket å finne svarene på disse spørsmålene *uten* å bli bedt om å logge inn hvert femte sekund? Uten reklamer og uten videoer som spiller av automatisk? Uten å måtte stole på et multinasjonalt konglomerat som prøver å selge deg ting?
+
+Da vil du elske Callsheet.
+
+Callsheet er den beste måten å raskt finne informasjon om medvirkende og besetning i TV og filmer. Den respekterer tiden din, prøver ikke å selge deg ting du ikke trenger, og er designet for å svare raskt og enkelt på spørsmålene dine.
+
+Callsheet har også noen nyskapende funksjoner som din forrige favorittdatabase-app ikke har:
+
+• Forhindre spoilere når du ser på TV-serier ved å valgfritt skjule karakternavn, episodeteller, episodetitler eller episodethumbnails. Ikke la deg selv bli spoilet om en karakters hemmelige identitet, eller at de plutselig forlater showet, ved å skjule denne informasjonen.
+• Rask tilgang til trivia, Wikipedia, aldersanbefalinger og hvor du kan se (levert av JustWatch).
+• Fest TV-serier, filmer eller personer for rask tilgang.
+• Finn ting du har søkt etter tidligere ved å bruke nylige søk og søkeloggen.
+• Se enkelt alderen på de medvirkende *når en film ble utgitt* sammen med rollelisten.
+• Du kan enkelt se alderen til en person for hver oppføring i filmografien deres.
+• Du kan lett se høyden til skuespillere (når informasjonen er tilgjengelig).
+• Støtte for mørk modus.
+• Støtte for VoiceOver.
+• Alternative app-ikoner for abonnenter.
+• Automatisk integrasjon uten innlogging med den fantastiske Channels-appen.
+• Eksperimentell integrasjon med Plex uten innlogging.
+
+Callsheet er skrevet av én person, som VIRKELIG bryr seg om å respektere tiden din. Callsheet er designet for å la deg enkelt finne det du trenger uten problemer, og deretter komme tilbake til filmen eller serien du virkelig bryr deg om. Ingen distraksjoner og ingen forespørsler om å logge inn.
+
+Callsheet tilbyr 20 gratissøk, og krever deretter et abonnement. Abonnementene kommer alle med en 1-ukes gratis prøveperiode. De støtter Familiedeling.
+
+Prøv Callsheet. Du vil ikke tro hvor mye bedre den er enn appen du brukte tidligere.

--- a/AppStore/Norwegian/PromoText.txt
+++ b/AppStore/Norwegian/PromoText.txt
@@ -1,0 +1,1 @@
+Finn informasjon om favorittfilmene og -seriene dine, uten stadige påloggingsanvisninger, annonser, videoer som spilles av automatisk osv. Oppdag filmer som to personer har jobbet med sammen.

--- a/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
+++ b/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
@@ -137,11 +137,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="Add Pin" xml:space="preserve">
-        <source>Add Pin</source>
+        <source>Add Pin</source><target>Fest</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add pin" xml:space="preserve">
-        <source>Add pin</source>
+        <source>Add pin</source><target>Fest</target>
         <note/>
       </trans-unit>
       <trans-unit id="Ages" xml:space="preserve">
@@ -411,15 +411,15 @@
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Free Trial" xml:space="preserve">
-        <source>Free Trial</source>
+        <source>Free Trial</source><target>Gratis prøveperiode</target>
         <note/>
       </trans-unit>
       <trans-unit id="Free searches remaining" xml:space="preserve">
-        <source>Free searches remaining</source>
+        <source>Free searches remaining</source><target>Gjenstående gratissøk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Free stuff doesn't last forever." xml:space="preserve">
-        <source>Free stuff doesn't last forever.</source>
+        <source>Free stuff doesn't last forever.</source><target>Gratis ting varer ikke evig.</target>
         <note>Subtitle for "Unlimited searches"; shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Free, but you can only ask once. 😏" xml:space="preserve">
@@ -499,7 +499,7 @@
         <note>Name of the annual subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Max Display Name" xml:space="preserve">
-        <source>Yearly Max-Supporter</source><target>Årlig Max-supporter</target>
+        <source>Yearly Max-Supporter</source><target>Årlig max-supporter</target>
         <note>Name of the annual subscription that is a bit more money than the normal one</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Ultra Description" xml:space="preserve">
@@ -507,7 +507,7 @@
         <note>Description for the maximum-cost annual subscription</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Ultra Display Name" xml:space="preserve">
-        <source>Yearly Ultra-Supporter</source><target>Årlig Ultra-Supporter</target>
+        <source>Yearly Ultra-Supporter</source><target>Årlig ultra-supporter</target>
         <note>Name of the maximum-cost annual subscription </note>
       </trans-unit>
       <trans-unit id="If you play something using [Channels](https://getchannels.com/) or [Plex](https://plex.tv/) on another device, Callsheet can display that show or movie at the top of the Discover screen." xml:space="preserve">
@@ -599,15 +599,15 @@
         <note>On cast list, display movies, shows, or movies &amp; shows</note>
       </trans-unit>
       <trans-unit id="Movies &amp; Shows" xml:space="preserve">
-        <source>Movies &amp; Shows</source><target>Filmer &amp; Serier</target>
+        <source>Movies &amp; Shows</source><target>Filmer &amp; serier</target>
         <note>On cast list, display movies, shows, or movies &amp; shows</note>
       </trans-unit>
       <trans-unit id="Movies and TV shows will show one link for quick access. The others are available in the More menu." xml:space="preserve">
-        <source>Movies and TV shows will show one link for quick access. The others are available in the More menu.</source><target>Filmer og TV-programmer viser én lenke for rask tilgang. De andre er tilgjengelige i Mer-menyen.</target>
+        <source>Movies and TV shows will show one link for quick access. The others are available in the More menu.</source><target>Filmer og TV-serier viser én lenke for rask tilgang. De andre er tilgjengelige i Mer-menyen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Movies featuring" xml:space="preserve">
-        <source>Movies featuring</source>
+        <source>Movies featuring</source><target>Filmer med</target>
         <note>Title for cast union view</note>
       </trans-unit>
       <trans-unit id="Name or job" xml:space="preserve">
@@ -619,19 +619,19 @@
         <note>Cast search prompt</note>
       </trans-unit>
       <trans-unit id="New Episodes" xml:space="preserve">
-        <source>New Episodes</source><target>Nye Episoder</target>
+        <source>New Episodes</source><target>Nye episoder</target>
         <note/>
       </trans-unit>
       <trans-unit id="New Movies" xml:space="preserve">
-        <source>New Movies</source><target>Nye Filmer</target>
+        <source>New Movies</source><target>Nye filmer</target>
         <note/>
       </trans-unit>
       <trans-unit id="Newest First" xml:space="preserve">
-        <source>Newest First</source><target>Nyeste Først</target>
+        <source>Newest First</source><target>Nyeste først</target>
         <note>When setting sort order</note>
       </trans-unit>
       <trans-unit id="Next Episode" xml:space="preserve">
-        <source>Next Episode</source><target>Neste Episode</target>
+        <source>Next Episode</source><target>Neste episode</target>
         <note/>
       </trans-unit>
       <trans-unit id="No TV show pins found." xml:space="preserve">
@@ -691,7 +691,7 @@
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Now Playing" xml:space="preserve">
-        <source>Now Playing</source><target>Spilles nå</target>
+        <source>Now Playing</source><target>Spiller nå</target>
         <note>A header on the home screen &amp; a row in Settings; shows what is currently playing in Plex and/or Channels.</note>
       </trans-unit>
       <trans-unit id="OK" xml:space="preserve">
@@ -743,7 +743,7 @@
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="Pin Type" xml:space="preserve">
-        <source>Pin Type</source>
+        <source>Pin Type</source><target>Type element</target>
         <note>Shown in the list of pins screen</note>
       </trans-unit>
       <trans-unit id="Pin your favorites for quick access." xml:space="preserve">
@@ -751,11 +751,11 @@
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
-        <source>Pinned Items</source>
+        <source>Pinned Items</source><target>Festede Elementer</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pinned items" xml:space="preserve">
-        <source>Pinned items</source>
+        <source>Pinned items</source><target>Festede elementer</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Plans:" xml:space="preserve">
@@ -783,7 +783,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Prevent giving away spoilers by choosing to redact details." xml:space="preserve">
-        <source>Prevent giving away spoilers by choosing to redact details.</source><target>Unngå å avsløre spoilere ved å velge å skjule detaljer.</target>
+        <source>Prevent giving away spoilers by choosing to redact details.</source><target>Unngå spoilere ved å velge å skjule detaljer.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Preview" xml:space="preserve">
@@ -859,11 +859,11 @@
         <note>When a TV episode or movie will be released</note>
       </trans-unit>
       <trans-unit id="Remove Pin" xml:space="preserve">
-        <source>Remove Pin</source>
+        <source>Remove Pin</source><target>Fjern festet element</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove pin" xml:space="preserve">
-        <source>Remove pin</source>
+        <source>Remove pin</source><target>Fjern festet element</target>
         <note/>
       </trans-unit>
       <trans-unit id="Request Refund" xml:space="preserve">
@@ -903,7 +903,7 @@
         <note>Encouraging users to save money by purchasing a yearly subscription — "Save 17%"</note>
       </trans-unit>
       <trans-unit id="Score" xml:space="preserve">
-        <source>Score</source>
+        <source>Score</source><target>Vurdering</target>
         <note>A 0-100 score of the quality of a movie/show</note>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
@@ -919,7 +919,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Season %lld Episode %lld" xml:space="preserve">
-        <source>Season %1$lld Episode %2$lld</source><target>Sesong %1$lld Episode %2$lld</target>
+        <source>Season %1$lld Episode %2$lld</source><target>Sesong %1$lld episode %2$lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="Seasons" xml:space="preserve">
@@ -947,7 +947,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Share Callsheet link…" xml:space="preserve">
-        <source>Share Callsheet link…</source><target>Del lenke til Callsheet</target>
+        <source>Share Callsheet link…</source><target>Del lenke til Callsheet…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Share web link" xml:space="preserve">
@@ -955,7 +955,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Share web link…" xml:space="preserve">
-        <source>Share web link…</source><target>Del weblenke</target>
+        <source>Share web link…</source><target>Del weblenke…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shared image" xml:space="preserve">
@@ -1211,7 +1211,7 @@
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
-        <source>pinned items</source>
+        <source>pinned items</source><target>festede elementer</target>
         <note/>
       </trans-unit>
       <trans-unit id="visionOS does not support changing icons yet." xml:space="preserve">

--- a/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
+++ b/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
@@ -37,103 +37,103 @@
         <note/>
       </trans-unit>
       <trans-unit id="#%lld" xml:space="preserve">
-        <source>#%lld</source>
+        <source>#%lld</source><target>#%lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="#%llu" xml:space="preserve">
-        <source>#%llu</source>
+        <source>#%llu</source><target>#%llu</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@" xml:space="preserve">
-        <source>%@</source>
+        <source>%@</source><target>%@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ (%@)" xml:space="preserve">
-        <source>%1$@ (%2$@)</source>
+        <source>%1$@ (%2$@)</source><target>%1$@ (%2$@)</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ - %@" xml:space="preserve">
-        <source>%1$@ - %2$@</source>
+        <source>%1$@ - %2$@</source><target>%1$@ - %2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ / %@" xml:space="preserve">
-        <source>%1$@ / %2$@</source>
+        <source>%1$@ / %2$@</source><target>%1$@ / %2$@</target>
         <note/>
       </trans-unit>
       <trans-unit id="%@ by %@" xml:space="preserve">
-        <source>%1$@ by %2$@</source>
+        <source>%1$@ by %2$@</source><target>%1$@ by %2$@</target>
         <note>{Icon name} by {Icon artist}</note>
       </trans-unit>
       <trans-unit id="%lld" xml:space="preserve">
-        <source>%lld</source>
+        <source>%lld</source><target>%lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld Season|==|plural.one" xml:space="preserve">
-        <source>%lld Season</source>
+        <source>%lld Season</source><target>%lld sesong</target>
         <note>Shown in the TV seasons carousel (on the TV show screen)</note>
       </trans-unit>
       <trans-unit id="%lld Season|==|plural.other" xml:space="preserve">
-        <source>%lld Seasons</source>
+        <source>%lld Seasons</source><target>%lld sesonger</target>
         <note>Shown in the TV seasons carousel (on the TV show screen)</note>
       </trans-unit>
       <trans-unit id="%lld episode|==|plural.one" xml:space="preserve">
-        <source>%lld episode</source>
+        <source>%lld episode</source><target>%lld episode</target>
         <note>How many episodes a person has been appeared in for a TV show, or how many episodes are in a TV season</note>
       </trans-unit>
       <trans-unit id="%lld episode|==|plural.other" xml:space="preserve">
-        <source>%lld episodes</source>
+        <source>%lld episodes</source><target>%lld episoder</target>
         <note>How many episodes a person has been appeared in for a TV show, or how many episodes are in a TV season</note>
       </trans-unit>
       <trans-unit id="%lld free search remaining|==|plural.one" xml:space="preserve">
-        <source>%lld free search remaining</source>
+        <source>%lld free search remaining</source><target>%lld gjenstående gratis søk</target>
         <note>Shown on the main/bottom bar when the user has fewer than 10 of their free searches left</note>
       </trans-unit>
       <trans-unit id="%lld free search remaining|==|plural.other" xml:space="preserve">
-        <source>%lld free searches remaining</source>
+        <source>%lld free searches remaining</source><target>%lld gjenstående gratis søk</target>
         <note>Shown on the main/bottom bar when the user has fewer than 10 of their free searches left</note>
       </trans-unit>
       <trans-unit id="%lld minutes|==|plural.one" xml:space="preserve">
-        <source>%lld minute</source>
+        <source>%lld minute</source><target>%lld-minutt</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld minutes|==|plural.other" xml:space="preserve">
-        <source>%lld minutes</source>
+        <source>%lld minutes</source><target>%lld-minutter</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld of %lld" xml:space="preserve">
-        <source>%1$lld of %2$lld</source>
+        <source>%1$lld of %2$lld</source><target>%1$lld av %2$lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld year old|==|plural.one" xml:space="preserve">
-        <source>%lld year old</source>
+        <source>%lld year old</source><target>%lld år gammel</target>
         <note>The age of an actor at the time a piece of media was released</note>
       </trans-unit>
       <trans-unit id="%lld year old|==|plural.other" xml:space="preserve">
-        <source>%lld years old</source>
+        <source>%lld years old</source><target>%lld år gammel</target>
         <note>The age of an actor at the time a piece of media was released</note>
       </trans-unit>
       <trans-unit id="%lld years" xml:space="preserve">
-        <source>%lld years</source>
+        <source>%lld years</source><target>%lld år</target>
         <note>How old a person was when they passed</note>
       </trans-unit>
       <trans-unit id="%lld years old|==|plural.one" xml:space="preserve">
-        <source>%lld year old</source>
+        <source>%lld year old</source><target>%lld år gammel</target>
         <note>How old a person is right now</note>
       </trans-unit>
       <trans-unit id="%lld years old|==|plural.other" xml:space="preserve">
-        <source>%lld years old</source>
+        <source>%lld years old</source><target>%lld år gammel</target>
         <note>How old a person is right now</note>
       </trans-unit>
       <trans-unit id="%lld — " xml:space="preserve">
-        <source>%lld — </source>
+        <source>%lld — </source><target>%lld — </target>
         <note/>
       </trans-unit>
       <trans-unit id="A few more free ones please?" xml:space="preserve">
-        <source>A few more free ones please?</source>
+        <source>A few more free ones please?</source><target>Et par ekstra gratissøk, vær så snill?</target>
         <note>Shown on the "Additional options" purchasing screen, offering the user five more free searches</note>
       </trans-unit>
       <trans-unit id="About Callsheet" xml:space="preserve">
-        <source>About Callsheet</source>
+        <source>About Callsheet</source><target>Om Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add Pin" xml:space="preserve">
@@ -145,59 +145,59 @@
         <note/>
       </trans-unit>
       <trans-unit id="Ages" xml:space="preserve">
-        <source>Ages</source>
+        <source>Ages</source><target>Aldre</target>
         <note>Heading in Persnickety Preferences</note>
       </trans-unit>
       <trans-unit id="All" xml:space="preserve">
-        <source>All</source>
+        <source>All</source><target>Alle</target>
         <note/>
       </trans-unit>
       <trans-unit id="All Messages" xml:space="preserve">
-        <source>All Messages</source>
+        <source>All Messages</source><target>Alle meldinger</target>
         <note>Shown in the context of a semi-hidden debugging screen.</note>
       </trans-unit>
       <trans-unit id="App Icon" xml:space="preserve">
-        <source>App Icon</source>
+        <source>App Icon</source><target>Appikon</target>
         <note/>
       </trans-unit>
       <trans-unit id="Are you sure?" xml:space="preserve">
-        <source>Are you sure?</source>
+        <source>Are you sure?</source><target>Er du sikker?</target>
         <note>Shown when clearing recent searches or search history</note>
       </trans-unit>
       <trans-unit id="As rated by users of" xml:space="preserve">
-        <source>As rated by users of</source>
+        <source>As rated by users of</source><target>Som vurdert av brukere av</target>
         <note>Shown in a popover explaining TV/movie scores</note>
       </trans-unit>
       <trans-unit id="Average runtime" xml:space="preserve">
-        <source>Average runtime</source>
+        <source>Average runtime</source><target>Gjennomsnittlig episodelengde</target>
         <note>How long episodes run in a single season of TV</note>
       </trans-unit>
       <trans-unit id="Be a hero and support independent apps" xml:space="preserve">
-        <source>Be a hero and support independent apps</source>
+        <source>Be a hero and support independent apps</source><target>Vær en helt og støtt uavhengige apper</target>
         <note>Shown when trying to sell a subscription</note>
       </trans-unit>
       <trans-unit id="Be like the many other beautiful people who have rated this version." xml:space="preserve">
-        <source>Be like the many other beautiful people who have rated this version.</source>
+        <source>Be like the many other beautiful people who have rated this version.</source><target>Gjør som mange andre vakre mennesker og vurder denne versjonen</target>
         <note>Shown to try to encourage the user to rate the app</note>
       </trans-unit>
       <trans-unit id="Began Airing" xml:space="preserve">
-        <source>Began Airing</source>
+        <source>Began Airing</source><target>Begynte å strømme</target>
         <note>When a TV season started airing</note>
       </trans-unit>
       <trans-unit id="Begins Airing" xml:space="preserve">
-        <source>Begins Airing</source>
+        <source>Begins Airing</source><target>Begynner å strømme</target>
         <note>When a TV season will start airing</note>
       </trans-unit>
       <trans-unit id="Biography" xml:space="preserve">
-        <source>Biography</source>
+        <source>Biography</source><target>Biografi</target>
         <note/>
       </trans-unit>
       <trans-unit id="Born" xml:space="preserve">
-        <source>Born</source>
+        <source>Born</source><target>Født</target>
         <note/>
       </trans-unit>
       <trans-unit id="Browser" xml:space="preserve">
-        <source>Browser</source>
+        <source>Browser</source><target>Nettleser</target>
         <note/>
       </trans-unit>
       <trans-unit id="Callsheet" xml:space="preserve">
@@ -205,63 +205,63 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="Callsheet Premium" xml:space="preserve">
-        <source>Callsheet Premium</source>
+        <source>Callsheet Premium</source><target>Callsheet Premium</target>
         <note/>
       </trans-unit>
       <trans-unit id="Callsheet couldn't parse the information from The Movie Database." xml:space="preserve">
-        <source>Callsheet couldn't parse the information from The Movie Database.</source>
+        <source>Callsheet couldn't parse the information from The Movie Database.</source><target>Callsheet klarte ikke å tolke informasjonen fra The Movie Database.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Callsheet couldn't reach The Movie Database." xml:space="preserve">
-        <source>Callsheet couldn't reach The Movie Database.</source>
+        <source>Callsheet couldn't reach The Movie Database.</source><target>Callsheet kunne ikke kontakte The Movie Database.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Callsheet was built in Virginia by **[Casey Liss](https://www.caseyliss.com/)**." xml:space="preserve">
-        <source>Callsheet was built in Virginia by **[Casey Liss](https://www.caseyliss.com/)**.</source>
+        <source>Callsheet was built in Virginia by **[Casey Liss](https://www.caseyliss.com/)**.</source><target>Callsheet ble bygd i Virginia av **[Casey Liss](https://www.caseyliss.com/)**.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Cancel" xml:space="preserve">
-        <source>Cancel</source>
+        <source>Cancel</source><target>Avbryt</target>
         <note/>
       </trans-unit>
       <trans-unit id="Cancel Subscription" xml:space="preserve">
-        <source>Cancel Subscription</source>
+        <source>Cancel Subscription</source><target>Avslutt abonnement</target>
         <note/>
       </trans-unit>
       <trans-unit id="Cast" xml:space="preserve">
-        <source>Cast</source>
+        <source>Cast</source><target>Medvirkende</target>
         <note/>
       </trans-unit>
       <trans-unit id="Cast or Crew" xml:space="preserve">
-        <source>Cast or Crew</source>
+        <source>Cast or Crew</source><target>Medvirkende eller besetning</target>
         <note/>
       </trans-unit>
       <trans-unit id="Choose New Subscription" xml:space="preserve">
-        <source>Choose New Subscription</source>
+        <source>Choose New Subscription</source><target>Velg nytt abonnement</target>
         <note/>
       </trans-unit>
       <trans-unit id="Choose a link:" xml:space="preserve">
-        <source>Choose a link:</source>
+        <source>Choose a link:</source><target>Velg en lenke</target>
         <note>Shown in settings for the quick access link</note>
       </trans-unit>
       <trans-unit id="Choose a quick link" xml:space="preserve">
-        <source>Choose a quick link</source>
+        <source>Choose a quick link</source><target>Velg en hurtiglenke</target>
         <note>Accessibility label for the quick access picker in Persnickety Preferences</note>
       </trans-unit>
       <trans-unit id="Choose an icon that fits your aesthetic." xml:space="preserve">
-        <source>Choose an icon that fits your aesthetic.</source>
+        <source>Choose an icon that fits your aesthetic.</source><target>Velg et ikon som passer din stil.</target>
         <note>Subtitle for "Custom icons"; shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Choose spoiler-risky things to hide by default." xml:space="preserve">
-        <source>Choose spoiler-risky things to hide by default.</source>
-        <note>Subtitle for a row in Settings</note>
+        <source>Choose spoiler-risky things to hide by default.</source><target>Velg hva du vil ha skjult som standard for å unngå spoilere.</target>
+        <note>Subtitle for a row in Settings</note><note from="reviewer">Should be rewritten</note>
       </trans-unit>
       <trans-unit id="Clear" xml:space="preserve">
-        <source>Clear</source>
+        <source>Clear</source><target>Tøm</target>
         <note/>
       </trans-unit>
       <trans-unit id="Clear all" xml:space="preserve">
-        <source>Clear all</source>
+        <source>Clear all</source><target>Tøm alt</target>
         <note>Shown when clearing recent searches or search history</note>
       </trans-unit>
       <trans-unit id="Click Me" xml:space="preserve">
@@ -269,23 +269,23 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="Close" xml:space="preserve">
-        <source>Close</source>
+        <source>Close</source><target>Lukk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Connect to devices on your local network to show what's playing." xml:space="preserve">
-        <source>Connect to devices on your local network to show what's playing.</source>
+        <source>Connect to devices on your local network to show what's playing.</source><target>Koble til enheter på ditt lokale nettverk for å se hva som spilles.</target>
         <note>Subtitle in Persnickety Preferences</note>
       </trans-unit>
       <trans-unit id="Copy" xml:space="preserve">
-        <source>Copy</source>
+        <source>Copy</source><target>Kopier</target>
         <note/>
       </trans-unit>
       <trans-unit id="Copy Error Information" xml:space="preserve">
-        <source>Copy Error Information</source>
+        <source>Copy Error Information</source><target>Kopier feilinformasjon</target>
         <note/>
       </trans-unit>
       <trans-unit id="Copy e-mail address" xml:space="preserve">
-        <source>Copy e-mail address</source>
+        <source>Copy e-mail address</source><target>Kopier e-postadresse</target>
         <note/>
       </trans-unit>
       <trans-unit id="Could not load static JSON" xml:space="preserve">
@@ -297,71 +297,71 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="Credits" xml:space="preserve">
-        <source>Credits</source>
+        <source>Credits</source><target>Kreditter</target>
         <note>Shown as a header on the movie view for the mid- and post-credits scene icons</note>
       </trans-unit>
       <trans-unit id="Credits Lists" xml:space="preserve">
-        <source>Credits Lists</source>
+        <source>Credits Lists</source><target>Liste over kreditter</target>
         <note>Persnickety Preferences header</note>
       </trans-unit>
       <trans-unit id="Crew" xml:space="preserve">
-        <source>Crew</source>
+        <source>Crew</source><target>Besetning</target>
         <note/>
       </trans-unit>
       <trans-unit id="Custom icons" xml:space="preserve">
-        <source>Custom icons</source>
+        <source>Custom icons</source><target>Egendefinerte ikoner</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Data provided by The Movie Database" xml:space="preserve">
-        <source>Data provided by The Movie Database</source>
+        <source>Data provided by The Movie Database</source><target>Data hentet fra The Movie Database</target>
         <note/>
       </trans-unit>
       <trans-unit id="Data provided by:" xml:space="preserve">
-        <source>Data provided by:</source>
+        <source>Data provided by:</source><target>Data hentet fra:</target>
         <note/>
       </trans-unit>
       <trans-unit id="Default Spoiler Settings" xml:space="preserve">
-        <source>Default Spoiler Settings</source>
+        <source>Default Spoiler Settings</source><target>Standardinnstillinger for spoilere</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete recent searches" xml:space="preserve">
-        <source>Delete recent searches</source>
+        <source>Delete recent searches</source><target>Slett nylige søk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete search history" xml:space="preserve">
-        <source>Delete search history</source>
+        <source>Delete search history</source><target>Slett søkehistorikk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Details" xml:space="preserve">
-        <source>Details</source>
+        <source>Details</source><target>Detaljer</target>
         <note/>
       </trans-unit>
       <trans-unit id="Discover" xml:space="preserve">
-        <source>Discover</source>
+        <source>Discover</source><target>Utforsk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Done" xml:space="preserve">
-        <source>Done</source>
+        <source>Done</source><target>Ferdig</target>
         <note/>
       </trans-unit>
       <trans-unit id="Each TV show can have their own settings, set by tapping the `Hide` `Spoilers…` button when looking at a show or episode." xml:space="preserve">
-        <source>Each TV show can have their own settings, set by tapping the `Hide` `Spoilers…` button when looking at a show or episode.</source>
+        <source>Each TV show can have their own settings, set by tapping the `Hide` `Spoilers…` button when looking at a show or episode.</source><target>Hver TV-serie kan ha sine egne innstillinger, som kan settes ved å trykke på `Skjul` `spoilere…`-knappen når du ser på en serie eller en episode.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Ends at %@" xml:space="preserve">
-        <source>Ends at %@</source>
+        <source>Ends at %@</source><target>Ferdig klokka %@</target>
         <note>When a show or movie ends if you start it right now</note>
       </trans-unit>
       <trans-unit id="Episode" xml:space="preserve">
-        <source>Episode</source>
+        <source>Episode</source><target>Episode</target>
         <note/>
       </trans-unit>
       <trans-unit id="Episode Poster" xml:space="preserve">
-        <source>Episode Poster</source>
+        <source>Episode Poster</source><target>Episodeplakat</target>
         <note/>
       </trans-unit>
       <trans-unit id="Episode Scores" xml:space="preserve">
-        <source>Episode Scores</source>
+        <source>Episode Scores</source><target>Episodevurderinger</target>
         <note/>
       </trans-unit>
       <trans-unit id="Error: should not be able to reach settings from here." xml:space="preserve">
@@ -369,44 +369,45 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="Expired" xml:space="preserve">
-        <source>Expired</source>
+        <source>Expired</source><target>Utløpt</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Expires" xml:space="preserve">
-        <source>Expires</source>
+        <source>Expires</source><target>Utløper</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Export" xml:space="preserve">
-        <source>Export</source>
+        <source>Export</source><target>Eksporter</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Faults" xml:space="preserve">
-        <source>Faults</source>
+        <source>Faults</source><target>Feil og mangler</target>
         <note>Shown in the context of a semi-hidden debugging screen.</note>
       </trans-unit>
       <trans-unit id="Feedback emails are lovely to read!" xml:space="preserve">
-        <source>Feedback emails are lovely to read!</source>
+        <source>Feedback emails are lovely to read!</source><target>Tilbakemeldinger på e-post er alltid hyggelig!</target>
         <note>Shown in Settings to try to get users to rate the app</note>
       </trans-unit>
       <trans-unit id="Find a way to watch in:" xml:space="preserve">
-        <source>Find a way to watch in:</source>
+        <source>Find a way to watch in:</source><target>Finn en måte å strømme i:</target>
         <note>Shown when choosing a country to use for Where to Watch (long version)</note>
       </trans-unit>
       <trans-unit id="Find movies where&#10;%@ worked with:" xml:space="preserve">
         <source>Find movies where
-%@ worked with:</source>
+%@ worked with:</source><target>Finn filmer hvor
+%@ arbeidet med:</target>
         <note/>
       </trans-unit>
       <trans-unit id="Find shared film credits" xml:space="preserve">
-        <source>Find shared film credits</source>
+        <source>Find shared film credits</source><target>Finn delte </target>
         <note/>
       </trans-unit>
       <trans-unit id="For Where to Watch." xml:space="preserve">
-        <source>For Where to Watch.</source>
+        <source>For Where to Watch.</source><target>For hvor man kan se</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="For new &amp; popular media." xml:space="preserve">
-        <source>For new &amp; popular media.</source>
+        <source>For new &amp; popular media.</source><target>For ny- og populærmedia</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Free Trial" xml:space="preserve">
@@ -422,59 +423,59 @@
         <note>Subtitle for "Unlimited searches"; shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Free, but you can only ask once. 😏" xml:space="preserve">
-        <source>Free, but you can only ask once. 😏</source>
+        <source>Free, but you can only ask once. 😏</source><target>Gratis, men du kan bare spørre én gang. 😏</target>
         <note>Subtitle for the "A few more searches please" option on the "Additional options" purchasing screen</note>
       </trans-unit>
       <trans-unit id="Genre" xml:space="preserve">
-        <source>Genre</source>
+        <source>Genre</source><target>Sjanger</target>
         <note/>
       </trans-unit>
       <trans-unit id="Genres" xml:space="preserve">
-        <source>Genres</source>
+        <source>Genres</source><target>Sjangre</target>
         <note/>
       </trans-unit>
       <trans-unit id="Guests" xml:space="preserve">
-        <source>Guests</source>
+        <source>Guests</source><target>Gjester</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hand your phone to someone knowing they **cannot mess up your photos**." xml:space="preserve">
-        <source>Hand your phone to someone knowing they **cannot mess up your photos**.</source>
+        <source>Hand your phone to someone knowing they **cannot mess up your photos**.</source><target>Gi telefonen til noen og vit at de **ikke kan ødelegge bildene dine**.</target>
         <note>Peek-a-View subtitle in Settings</note>
       </trans-unit>
       <trans-unit id="Height" xml:space="preserve">
-        <source>Height</source>
+        <source>Height</source><target>Høyde</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hide Spoilers" xml:space="preserve">
-        <source>Hide Spoilers</source>
+        <source>Hide Spoilers</source><target>Skjul spoilere</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hide Spoilers…" xml:space="preserve">
-        <source>Hide Spoilers…</source>
+        <source>Hide Spoilers…</source><target>Skjul spoilere</target>
         <note/>
       </trans-unit>
       <trans-unit id="Hide cast character names" xml:space="preserve">
-        <source>Hide cast character names</source>
+        <source>Hide cast character names</source><target>Skjul karakternavn for medvirkende</target>
         <note>Toggle for TV spoiler settings</note>
       </trans-unit>
       <trans-unit id="Hide cast episode counts" xml:space="preserve">
-        <source>Hide cast episode counts</source>
+        <source>Hide cast episode counts</source><target>Skjul antall episoder for medvirkende</target>
         <note>Toggle for TV spoiler settings</note>
       </trans-unit>
       <trans-unit id="Hide episode thumbnails" xml:space="preserve">
-        <source>Hide episode thumbnails</source>
+        <source>Hide episode thumbnails</source><target>Skjul miniatyrbilder av episoder</target>
         <note>Toggle for TV spoiler settings</note>
       </trans-unit>
       <trans-unit id="Hide episode titles" xml:space="preserve">
-        <source>Hide episode titles</source>
+        <source>Hide episode titles</source><target>Skul episodetitler</target>
         <note>Toggle for TV spoiler settings</note>
       </trans-unit>
       <trans-unit id="Hide summaries" xml:space="preserve">
-        <source>Hide summaries</source>
+        <source>Hide summaries</source><target>Skjul sammendrag</target>
         <note>Toggle for TV spoiler settings</note>
       </trans-unit>
       <trans-unit id="How seasons and episodes are sorted." xml:space="preserve">
-        <source>How seasons and episodes are sorted.</source>
+        <source>How seasons and episodes are sorted.</source><target>Hvordan sesonger og episoder sorteres.</target>
         <note/>
       </trans-unit>
       <trans-unit id="I'm in a popover" xml:space="preserve">
@@ -482,59 +483,59 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="IAP: Monthly Description" xml:space="preserve">
-        <source>Unlimited searches for a month. Auto-renews</source>
+        <source>Unlimited searches for a month. Auto-renews</source><target>Ubegrenset antall søk i en måned. Fornyes automatisk.</target>
         <note>Description for the monthly subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Monthly Display Name" xml:space="preserve">
-        <source>Monthly</source>
+        <source>Monthly</source><target>Månedlig</target>
         <note>Name of the monthly subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Description" xml:space="preserve">
-        <source>Access to Callsheet for 1 year. Auto-renews</source>
+        <source>Access to Callsheet for 1 year. Auto-renews</source><target>Tilgang til Callsheet i 1 år. Fornyes automatisk.</target>
         <note>Description for the annual subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Display Name" xml:space="preserve">
-        <source>Yearly</source>
+        <source>Yearly</source><target>Årlig</target>
         <note>Name of the annual subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Max Display Name" xml:space="preserve">
-        <source>Yearly Max-Supporter</source>
+        <source>Yearly Max-Supporter</source><target>Årlig Max-supporter</target>
         <note>Name of the annual subscription that is a bit more money than the normal one</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Ultra Description" xml:space="preserve">
-        <source>Show your extreme support!</source>
+        <source>Show your extreme support!</source><target>Vis ekstrem støtte!</target>
         <note>Description for the maximum-cost annual subscription</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Ultra Display Name" xml:space="preserve">
-        <source>Yearly Ultra-Supporter</source>
+        <source>Yearly Ultra-Supporter</source><target>Årlig Ultra-Supporter</target>
         <note>Name of the maximum-cost annual subscription </note>
       </trans-unit>
       <trans-unit id="If you play something using [Channels](https://getchannels.com/) or [Plex](https://plex.tv/) on another device, Callsheet can display that show or movie at the top of the Discover screen." xml:space="preserve">
-        <source>If you play something using [Channels](https://getchannels.com/) or [Plex](https://plex.tv/) on another device, Callsheet can display that show or movie at the top of the Discover screen.</source>
+        <source>If you play something using [Channels](https://getchannels.com/) or [Plex](https://plex.tv/) on another device, Callsheet can display that show or movie at the top of the Discover screen.</source><target>Hvis du spiller av noe ved hjelp av [Channels] (https://getchannels.com/) eller [Plex] (https://plex.tv/) på en annen enhet, kan Callsheet vise det programmet eller den filmen øverst på Utforsk-skjermen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Image" xml:space="preserve">
-        <source>Image</source>
+        <source>Image</source><target>Bilde</target>
         <note/>
       </trans-unit>
       <trans-unit id="In Grace Period" xml:space="preserve">
-        <source>In Grace Period</source>
+        <source>In Grace Period</source><target>I gratisperioden</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="In Retry Period" xml:space="preserve">
-        <source>In Retry Period</source>
+        <source>In Retry Period</source><target>I gjentakelsesperioden</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="In-App Browser" xml:space="preserve">
-        <source>In-App Browser</source>
+        <source>In-App Browser</source><target>Nettleser i appen</target>
         <note>Which browser to use for web links (the other option is "Safari")</note>
       </trans-unit>
       <trans-unit id="In-Credits Bonus Scenes" xml:space="preserve">
-        <source>In-Credits Bonus Scenes</source>
+        <source>In-Credits Bonus Scenes</source><target>Bonusscener i rulleteksten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Integrations" xml:space="preserve">
-        <source>Integrations</source>
+        <source>Integrations</source><target>Integrasjoner</target>
         <note>Header in Persnickety Preferences</note>
       </trans-unit>
       <trans-unit id="JustWatch" xml:space="preserve">
@@ -542,67 +543,67 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="Known For" xml:space="preserve">
-        <source>Known For</source>
+        <source>Known For</source><target>Kjent for</target>
         <note/>
       </trans-unit>
       <trans-unit id="Language Override" xml:space="preserve">
-        <source>Language Override</source>
+        <source>Language Override</source><target>Overstyr språk</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Learn about the people behind Callsheet." xml:space="preserve">
-        <source>Learn about the people behind Callsheet.</source>
+        <source>Learn about the people behind Callsheet.</source><target>Lær mer om menneskene som står bak Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Lived" xml:space="preserve">
-        <source>Lived</source>
+        <source>Lived</source><target>Levde</target>
         <note>How long an actor lived</note>
       </trans-unit>
       <trans-unit id="Loading…" xml:space="preserve">
-        <source>Loading…</source>
+        <source>Loading…</source><target>Laster…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Macro State at %@" xml:space="preserve">
-        <source>Macro State at %@</source>
+        <source>Macro State at %@</source><target>Makrotilstand ved %@</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Manage Subscription" xml:space="preserve">
-        <source>Manage Subscription</source>
+        <source>Manage Subscription</source><target>Administrer abonnement</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mid-credits" xml:space="preserve">
-        <source>Mid-credits</source>
+        <source>Mid-credits</source><target>Midt i rulleteksten</target>
         <note/>
       </trans-unit>
       <trans-unit id="More Info…" xml:space="preserve">
-        <source>More Info…</source>
+        <source>More Info…</source><target>Mer info…</target>
         <note/>
       </trans-unit>
       <trans-unit id="More Purchase Options…" xml:space="preserve">
-        <source>More Purchase Options…</source>
+        <source>More Purchase Options…</source><target>Flere kjøpsmuligheter…</target>
         <note/>
       </trans-unit>
       <trans-unit id="More…" xml:space="preserve">
-        <source>More…</source>
+        <source>More…</source><target>Mer…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Movie Poster" xml:space="preserve">
-        <source>Movie Poster</source>
+        <source>Movie Poster</source><target>Filmplakat</target>
         <note/>
       </trans-unit>
       <trans-unit id="Movie Poster Placeholder" xml:space="preserve">
-        <source>Movie Poster Placeholder</source>
+        <source>Movie Poster Placeholder</source><target>Plassholder for filmplakat</target>
         <note>Accessibility label when a movie's poster is not available</note>
       </trans-unit>
       <trans-unit id="Movies" xml:space="preserve">
-        <source>Movies</source>
+        <source>Movies</source><target>Filmer</target>
         <note>On cast list, display movies, shows, or movies &amp; shows</note>
       </trans-unit>
       <trans-unit id="Movies &amp; Shows" xml:space="preserve">
-        <source>Movies &amp; Shows</source>
+        <source>Movies &amp; Shows</source><target>Filmer &amp; Serier</target>
         <note>On cast list, display movies, shows, or movies &amp; shows</note>
       </trans-unit>
       <trans-unit id="Movies and TV shows will show one link for quick access. The others are available in the More menu." xml:space="preserve">
-        <source>Movies and TV shows will show one link for quick access. The others are available in the More menu.</source>
+        <source>Movies and TV shows will show one link for quick access. The others are available in the More menu.</source><target>Filmer og TV-programmer viser én lenke for rask tilgang. De andre er tilgjengelige i Mer-menyen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Movies featuring" xml:space="preserve">
@@ -610,135 +611,135 @@
         <note>Title for cast union view</note>
       </trans-unit>
       <trans-unit id="Name or job" xml:space="preserve">
-        <source>Name or job</source>
+        <source>Name or job</source><target>Navn eller jobb</target>
         <note>Crew search prompt</note>
       </trans-unit>
       <trans-unit id="Name or role" xml:space="preserve">
-        <source>Name or role</source>
+        <source>Name or role</source><target>Navn eller rolle</target>
         <note>Cast search prompt</note>
       </trans-unit>
       <trans-unit id="New Episodes" xml:space="preserve">
-        <source>New Episodes</source>
+        <source>New Episodes</source><target>Nye Episoder</target>
         <note/>
       </trans-unit>
       <trans-unit id="New Movies" xml:space="preserve">
-        <source>New Movies</source>
+        <source>New Movies</source><target>Nye Filmer</target>
         <note/>
       </trans-unit>
       <trans-unit id="Newest First" xml:space="preserve">
-        <source>Newest First</source>
+        <source>Newest First</source><target>Nyeste Først</target>
         <note>When setting sort order</note>
       </trans-unit>
       <trans-unit id="Next Episode" xml:space="preserve">
-        <source>Next Episode</source>
+        <source>Next Episode</source><target>Neste Episode</target>
         <note/>
       </trans-unit>
       <trans-unit id="No TV show pins found." xml:space="preserve">
-        <source>No TV show pins found.</source>
+        <source>No TV show pins found.</source><target>Ingen festede TV-serier ble funnet. </target>
         <note/>
       </trans-unit>
       <trans-unit id="No credits found." xml:space="preserve">
-        <source>No credits found.</source>
+        <source>No credits found.</source><target>Ingen kreditter ble funnet</target>
         <note>Shown when a person has no cast nor crew credits</note>
       </trans-unit>
       <trans-unit id="No media found." xml:space="preserve">
-        <source>No media found.</source>
+        <source>No media found.</source><target>Ingen media ble funnet</target>
         <note>Shown when there's no data for new movies / new shows / etc</note>
       </trans-unit>
       <trans-unit id="No movie pins found." xml:space="preserve">
-        <source>No movie pins found.</source>
+        <source>No movie pins found.</source><target>Ingen festede filmer ble funnet</target>
         <note/>
       </trans-unit>
       <trans-unit id="No override" xml:space="preserve">
-        <source>No override</source>
+        <source>No override</source><target>Ingen overstyring</target>
         <note>Default option for language/region override</note>
       </trans-unit>
       <trans-unit id="No people found." xml:space="preserve">
-        <source>No people found.</source>
+        <source>No people found.</source><target>Ingen personer ble funnet</target>
         <note>Shown when a movie/show has no cast/crew</note>
       </trans-unit>
       <trans-unit id="No people matching *%@* found." xml:space="preserve">
-        <source>No people matching *%@* found.</source>
+        <source>No people matching *%@* found.</source><target>Ingen personer funner som matcher *%@*.</target>
         <note>Shown when searching a list of credits, but no matches were found</note>
       </trans-unit>
       <trans-unit id="No people pins found." xml:space="preserve">
-        <source>No people pins found.</source>
+        <source>No people pins found.</source><target>Ingen festede personer ble funnet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No pinned items found." xml:space="preserve">
-        <source>No pinned items found.</source>
+        <source>No pinned items found.</source><target>Ingen festede elementer ble funnet.</target>
         <note>Shown on the home screen</note>
       </trans-unit>
       <trans-unit id="No providers found." xml:space="preserve">
-        <source>No providers found.</source>
+        <source>No providers found.</source><target>Ingen tilbydere ble funnet.</target>
         <note>Shown when there's no data for Where to Watch</note>
       </trans-unit>
       <trans-unit id="No results found for &quot;%@&quot;" xml:space="preserve">
-        <source>No results found for "%@"</source>
+        <source>No results found for "%@"</source><target>Fant ingen resultater for "%@"</target>
         <note>Generic "couldn't find anything for this query" message</note>
       </trans-unit>
       <trans-unit id="No search history found." xml:space="preserve">
-        <source>No search history found.</source>
+        <source>No search history found.</source><target>Ingen søkehistorikk ble funnet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Not a subscription" xml:space="preserve">
-        <source>Not a subscription</source>
+        <source>Not a subscription</source><target>Ikke et abonnement.</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Not purchased" xml:space="preserve">
-        <source>Not purchased</source>
+        <source>Not purchased</source><target>Ikke kjøpt</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Now Playing" xml:space="preserve">
-        <source>Now Playing</source>
+        <source>Now Playing</source><target>Spilles nå</target>
         <note>A header on the home screen &amp; a row in Settings; shows what is currently playing in Plex and/or Channels.</note>
       </trans-unit>
       <trans-unit id="OK" xml:space="preserve">
-        <source>OK</source>
+        <source>OK</source><target>OK</target>
         <note/>
       </trans-unit>
       <trans-unit id="Oldest First" xml:space="preserve">
-        <source>Oldest First</source>
+        <source>Oldest First</source><target>Eldste først</target>
         <note>When setting sort order</note>
       </trans-unit>
       <trans-unit id="Optionally, you can choose to help more." xml:space="preserve">
-        <source>Optionally, you can choose to help more.</source>
+        <source>Optionally, you can choose to help more.</source><target>Du kan om du ønsker velge å bidra mer. </target>
         <note>Shown when trying to upsell the user on expensive subscriptions</note>
       </trans-unit>
       <trans-unit id="Other Great Apps" xml:space="preserve">
-        <source>Other Great Apps</source>
+        <source>Other Great Apps</source><target>Andre flotte apper</target>
         <note>Shown above Maskeraid &amp; Peek‑a‑View</note>
       </trans-unit>
       <trans-unit id="Other person" xml:space="preserve">
-        <source>Other person</source>
+        <source>Other person</source><target>Annen person</target>
         <note>Shown when doing cast union search for movies</note>
       </trans-unit>
       <trans-unit id="Other settings for more _particular_ users." xml:space="preserve">
-        <source>Other settings for more _particular_ users.</source>
+        <source>Other settings for more _particular_ users.</source><target>Andre innstillinger for mer _særskilte_ brukere.</target>
         <note>Subtitle for Persnickety Preferences in Settings</note>
       </trans-unit>
       <trans-unit id="Parental Guidance" xml:space="preserve">
-        <source>Parental Guidance</source>
+        <source>Parental Guidance</source><target>Foreldreveiledning</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Parental guidance won't be shown for cast and crew." xml:space="preserve">
-        <source>Parental guidance won't be shown for cast and crew.</source>
+        <source>Parental guidance won't be shown for cast and crew.</source><target>Foreldreveiledning vil ikke bli vist for medvirkende og besetning.</target>
         <note>Shown in Quick Access settings when the user selects Parental Guidance as their Quick Access button</note>
       </trans-unit>
       <trans-unit id="Persnickety Preferences" xml:space="preserve">
-        <source>Persnickety Preferences</source>
+        <source>Persnickety Preferences</source><target>Pirkete innstillinger</target>
         <note/>
       </trans-unit>
       <trans-unit id="Persnickety Prefs" xml:space="preserve">
-        <source>Persnickety Prefs</source>
-        <note>Navigation title for Persnickety Preferences in Settings</note>
+        <source>Persnickety Prefs</source><target>Pirkete innstillinger</target>
+        <note>Navigation title for Persnickety Preferences in Settings</note><note from="reviewer">Could also use "Pedantiske innstillinger" depending on the vibe you want to go for.</note>
       </trans-unit>
       <trans-unit id="Pick a country" xml:space="preserve">
-        <source>Pick a country</source>
+        <source>Pick a country</source><target>Velg et land</target>
         <note>Picker label for accessibility purposes, in Where to Watch</note>
       </trans-unit>
       <trans-unit id="Pin" xml:space="preserve">
-        <source>Pin</source>
+        <source>Pin</source><target>Fest</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="Pin Type" xml:space="preserve">
@@ -746,7 +747,7 @@
         <note>Shown in the list of pins screen</note>
       </trans-unit>
       <trans-unit id="Pin your favorites for quick access." xml:space="preserve">
-        <source>Pin your favorites for quick access.</source>
+        <source>Pin your favorites for quick access.</source><target>Fest favorittene dine for raskere tilgang.</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
@@ -758,35 +759,35 @@
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Plans:" xml:space="preserve">
-        <source>Plans:</source>
+        <source>Plans:</source><target>Abonnementer:</target>
         <note>In the context of different subscription/IAP plans</note>
       </trans-unit>
       <trans-unit id="Popular Movies" xml:space="preserve">
-        <source>Popular Movies</source>
+        <source>Popular Movies</source><target>Populære filmer</target>
         <note/>
       </trans-unit>
       <trans-unit id="Popular TV Shows" xml:space="preserve">
-        <source>Popular TV Shows</source>
+        <source>Popular TV Shows</source><target>Populære TV-serier</target>
         <note/>
       </trans-unit>
       <trans-unit id="Portrait" xml:space="preserve">
-        <source>Portrait</source>
+        <source>Portrait</source><target>Portrett</target>
         <note/>
       </trans-unit>
       <trans-unit id="Post-credits" xml:space="preserve">
-        <source>Post-credits</source>
+        <source>Post-credits</source><target>Etter rulleteksten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Poster" xml:space="preserve">
-        <source>Poster</source>
+        <source>Poster</source><target>Plakat</target>
         <note/>
       </trans-unit>
       <trans-unit id="Prevent giving away spoilers by choosing to redact details." xml:space="preserve">
-        <source>Prevent giving away spoilers by choosing to redact details.</source>
+        <source>Prevent giving away spoilers by choosing to redact details.</source><target>Unngå å avsløre spoilere ved å velge å skjule detaljer.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Preview" xml:space="preserve">
-        <source>Preview</source>
+        <source>Preview</source><target>Forhåndsvis</target>
         <note/>
       </trans-unit>
       <trans-unit id="Preview Title" xml:space="preserve">
@@ -794,67 +795,67 @@
         <note>Do not localize</note>
       </trans-unit>
       <trans-unit id="Privacy Policy" xml:space="preserve">
-        <source>Privacy Policy</source>
+        <source>Privacy Policy</source><target>Personvernerklæring</target>
         <note/>
       </trans-unit>
       <trans-unit id="Provided by" xml:space="preserve">
-        <source>Provided by</source>
+        <source>Provided by</source><target>Levert av</target>
         <note>In the context of "Provided by JustWatch"</note>
       </trans-unit>
       <trans-unit id="Provided by [JustWatch](https://www.justwatch.com/)" xml:space="preserve">
-        <source>Provided by [JustWatch](https://www.justwatch.com/)</source>
+        <source>Provided by [JustWatch](https://www.justwatch.com/)</source><target>Levert av [JustWatch](https://www.justwatch.com/)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Purchase Error" xml:space="preserve">
-        <source>Purchase Error</source>
+        <source>Purchase Error</source><target>Feil ved kjøp</target>
         <note/>
       </trans-unit>
       <trans-unit id="Purchased" xml:space="preserve">
-        <source>Purchased</source>
+        <source>Purchased</source><target>Kjøpt</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Purchasing…" xml:space="preserve">
-        <source>Purchasing…</source>
+        <source>Purchasing…</source><target>Kjøper…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Quick Access Link" xml:space="preserve">
-        <source>Quick Access Link</source>
+        <source>Quick Access Link</source><target>Lenke til hurtigtilgang</target>
         <note>Title of the Quick Access Link screen in Settings</note>
       </trans-unit>
       <trans-unit id="Quickly place emoji on photos — for privacy or fun!" xml:space="preserve">
-        <source>Quickly place emoji on photos — for privacy or fun!</source>
+        <source>Quickly place emoji on photos — for privacy or fun!</source><target>Plasser raskt emoji på bilder - for privatlivet eller for moro skyld!</target>
         <note>MaskerAid subtitle in Settings</note>
       </trans-unit>
       <trans-unit id="Rate this version of Callsheet" xml:space="preserve">
-        <source>Rate this version of Callsheet</source>
+        <source>Rate this version of Callsheet</source><target>Vurder denne versjonen av Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Rating" xml:space="preserve">
-        <source>Rating</source>
+        <source>Rating</source><target>Vurdering</target>
         <note>A content rating like G/PG/PG-13/R</note>
       </trans-unit>
       <trans-unit id="Recent Searches" xml:space="preserve">
-        <source>Recent Searches</source>
+        <source>Recent Searches</source><target>Nylige søk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Refresh" xml:space="preserve">
-        <source>Refresh</source>
+        <source>Refresh</source><target>Oppdater</target>
         <note/>
       </trans-unit>
       <trans-unit id="Region Override" xml:space="preserve">
-        <source>Region Override</source>
+        <source>Region Override</source><target>Overstyr region</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Released" xml:space="preserve">
-        <source>Released</source>
+        <source>Released</source><target>Utgitt</target>
         <note>When a TV episode or movie was released in the past</note>
       </trans-unit>
       <trans-unit id="Released " xml:space="preserve">
-        <source>Released </source>
+        <source>Released </source><target>Utgitt </target>
         <note/>
       </trans-unit>
       <trans-unit id="Releases" xml:space="preserve">
-        <source>Releases</source>
+        <source>Releases</source><target>Utgivelser</target>
         <note>When a TV episode or movie will be released</note>
       </trans-unit>
       <trans-unit id="Remove Pin" xml:space="preserve">
@@ -866,39 +867,39 @@
         <note/>
       </trans-unit>
       <trans-unit id="Request Refund" xml:space="preserve">
-        <source>Request Refund</source>
+        <source>Request Refund</source><target>Be om refusjon</target>
         <note/>
       </trans-unit>
       <trans-unit id="Restore Purchase" xml:space="preserve">
-        <source>Restore Purchase</source>
+        <source>Restore Purchase</source><target>Gjenopprett kjøp</target>
         <note/>
       </trans-unit>
       <trans-unit id="Reverse sort order" xml:space="preserve">
-        <source>Reverse sort order</source>
+        <source>Reverse sort order</source><target>Reverser sorteringsrekkefølgen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Revoked" xml:space="preserve">
-        <source>Revoked</source>
+        <source>Revoked</source><target>Opphevet</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Runtime" xml:space="preserve">
-        <source>Runtime</source>
+        <source>Runtime</source><target>Spilletid</target>
         <note>Heading for the total runtime of a TV episode</note>
       </trans-unit>
       <trans-unit id="Safari" xml:space="preserve">
-        <source>Safari</source>
+        <source>Safari</source><target>Safari</target>
         <note>Which browser to use for web links (the other option is "In-App Browser")</note>
       </trans-unit>
       <trans-unit id="Same perks as all other plans" xml:space="preserve">
-        <source>Same perks as all other plans</source>
+        <source>Same perks as all other plans</source><target>Samme fordeler som</target>
         <note>Shown when trying to sell a subscription</note>
       </trans-unit>
       <trans-unit id="Save" xml:space="preserve">
-        <source>Save</source>
+        <source>Save</source><target>Lagre</target>
         <note/>
       </trans-unit>
       <trans-unit id="Save %@" xml:space="preserve">
-        <source>Save %@</source>
+        <source>Save %@</source><target>Lagre %@</target>
         <note>Encouraging users to save money by purchasing a yearly subscription — "Save 17%"</note>
       </trans-unit>
       <trans-unit id="Score" xml:space="preserve">
@@ -906,143 +907,143 @@
         <note>A 0-100 score of the quality of a movie/show</note>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
-        <source>Search</source>
+        <source>Search</source><target>Søk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Search History" xml:space="preserve">
-        <source>Search History</source>
+        <source>Search History</source><target>Søkehistorikk</target>
         <note>Title of the Search History screen</note>
       </trans-unit>
       <trans-unit id="Search history" xml:space="preserve">
-        <source>Search history</source>
+        <source>Search history</source><target>Søkehistorikk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Season %lld Episode %lld" xml:space="preserve">
-        <source>Season %1$lld Episode %2$lld</source>
+        <source>Season %1$lld Episode %2$lld</source><target>Sesong %1$lld Episode %2$lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="Seasons" xml:space="preserve">
-        <source>Seasons</source>
+        <source>Seasons</source><target>Sesonger</target>
         <note>Navigation title for the screen showing the seasons of a TV show; NOT spring/summer</note>
       </trans-unit>
       <trans-unit id="Select a View" xml:space="preserve">
-        <source>Select a View</source>
+        <source>Select a View</source><target>Velg en visning</target>
         <note>Shown when choosing between cast &amp; crew</note>
       </trans-unit>
       <trans-unit id="Send Feedback" xml:space="preserve">
-        <source>Send Feedback</source>
+        <source>Send Feedback</source><target>Send tilbakemelding</target>
         <note/>
       </trans-unit>
       <trans-unit id="Settings" xml:space="preserve">
-        <source>Settings</source>
+        <source>Settings</source><target>Innstillinger</target>
         <note/>
       </trans-unit>
       <trans-unit id="Share" xml:space="preserve">
-        <source>Share</source>
+        <source>Share</source><target>Del</target>
         <note/>
       </trans-unit>
       <trans-unit id="Share Callsheet link" xml:space="preserve">
-        <source>Share Callsheet link</source>
+        <source>Share Callsheet link</source><target>Del lenke til Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Share Callsheet link…" xml:space="preserve">
-        <source>Share Callsheet link…</source>
+        <source>Share Callsheet link…</source><target>Del lenke til Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Share web link" xml:space="preserve">
-        <source>Share web link</source>
+        <source>Share web link</source><target>Del weblenke</target>
         <note/>
       </trans-unit>
       <trans-unit id="Share web link…" xml:space="preserve">
-        <source>Share web link…</source>
+        <source>Share web link…</source><target>Del weblenke</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shared image" xml:space="preserve">
-        <source>Shared image</source>
+        <source>Shared image</source><target>Delt bilde</target>
         <note>Export preview</note>
       </trans-unit>
       <trans-unit id="Show Poster" xml:space="preserve">
-        <source>Show Poster</source>
+        <source>Show Poster</source><target>Vis plakat</target>
         <note>Accessibility label</note>
       </trans-unit>
       <trans-unit id="Show Poster Placeholder" xml:space="preserve">
-        <source>Show Poster Placeholder</source>
+        <source>Show Poster Placeholder</source><target>Vis plassholder for plakat</target>
         <note>Shown in an accessibility label</note>
       </trans-unit>
       <trans-unit id="Show Spoilers" xml:space="preserve">
-        <source>Show Spoilers</source>
+        <source>Show Spoilers</source><target>Vis spoilere</target>
         <note/>
       </trans-unit>
       <trans-unit id="Show age information within credits lists. Ages are always shown for birth/death dates." xml:space="preserve">
-        <source>Show age information within credits lists. Ages are always shown for birth/death dates.</source>
+        <source>Show age information within credits lists. Ages are always shown for birth/death dates.</source><target>Vis alder i listen over kreditter. Alderen vises alltid for fødsels-/dødsdatoen.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Show movies, shows, or both in credit lists." xml:space="preserve">
-        <source>Show movies, shows, or both in credit lists.</source>
+        <source>Show movies, shows, or both in credit lists.</source><target>Vis filmer, TV-serier eller begge i listen over kreditter. </target>
         <note>Persnickety Preferences subtitle</note>
       </trans-unit>
       <trans-unit id="Show that you _really_ care" xml:space="preserve">
-        <source>Show that you _really_ care</source>
+        <source>Show that you _really_ care</source><target>Vis at _virkelig_ bryr deg.</target>
         <note>Shown when trying to sell a subscription</note>
       </trans-unit>
       <trans-unit id="Show titles a person may be known from." xml:space="preserve">
-        <source>Show titles a person may be known from.</source>
+        <source>Show titles a person may be known from.</source><target>Vis titler en person kan være kjent fra.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Sorry, there was a problem." xml:space="preserve">
-        <source>Sorry, there was a problem.</source>
+        <source>Sorry, there was a problem.</source><target>Beklager, det oppsto et problem.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Sort Order" xml:space="preserve">
-        <source>Sort Order</source>
+        <source>Sort Order</source><target>Sorteringsrekkefølge</target>
         <note/>
       </trans-unit>
       <trans-unit id="Spoiler Settings" xml:space="preserve">
-        <source>Spoiler Settings</source>
+        <source>Spoiler Settings</source><target>Innstillinger for spoilere</target>
         <note/>
       </trans-unit>
       <trans-unit id="Spoilers" xml:space="preserve">
-        <source>Spoilers</source>
+        <source>Spoilers</source><target>Spoilere</target>
         <note>Title for the row in Settings to get you to the default Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Subscribe" xml:space="preserve">
-        <source>Subscribe</source>
+        <source>Subscribe</source><target>Abonner</target>
         <note/>
       </trans-unit>
       <trans-unit id="Subscribed" xml:space="preserve">
-        <source>Subscribed</source>
+        <source>Subscribed</source><target>Abonnert</target>
         <note/>
       </trans-unit>
       <trans-unit id="Subscribers can change the app’s icon." xml:space="preserve">
-        <source>Subscribers can change the app’s icon.</source>
+        <source>Subscribers can change the app’s icon.</source><target>Abonnementer kan endre ikonet på appen.</target>
         <note>Subtitle for the App Icon row in Settings</note>
       </trans-unit>
       <trans-unit id="Subscription Status" xml:space="preserve">
-        <source>Subscription Status</source>
+        <source>Subscription Status</source><target>Abonnementsstatus</target>
         <note/>
       </trans-unit>
       <trans-unit id="Subscriptions Debugging" xml:space="preserve">
-        <source>Subscriptions Debugging</source>
+        <source>Subscriptions Debugging</source><target>Abonnementsfeilsøking</target>
         <note>Title of a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Summary" xml:space="preserve">
-        <source>Summary</source>
+        <source>Summary</source><target>Sammendrag</target>
         <note/>
       </trans-unit>
       <trans-unit id="TV Shows" xml:space="preserve">
-        <source>TV Shows</source>
+        <source>TV Shows</source><target>TV-serier</target>
         <note>On cast list, display movies, shows, or movies &amp; shows</note>
       </trans-unit>
       <trans-unit id="Technical Details" xml:space="preserve">
-        <source>Technical Details</source>
+        <source>Technical Details</source><target>Tekniske detaljer</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Terms of Service" xml:space="preserve">
-        <source>Terms of Service</source>
+        <source>Terms of Service</source><target>Vilkår for bruk av tjenesten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Thank you for trying out Callsheet. 💙" xml:space="preserve">
-        <source>Thank you for trying out Callsheet. 💙</source>
+        <source>Thank you for trying out Callsheet. 💙</source><target>Takk for at du prøver Callsheet. 💙</target>
         <note/>
       </trans-unit>
       <trans-unit id="The Movie Database" xml:space="preserve">
@@ -1050,163 +1051,163 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="There is no watch information available for *%@*." xml:space="preserve">
-        <source>There is no watch information available for *%@*.</source>
+        <source>There is no watch information available for *%@*.</source><target>Det finnes ingen seerinformasjon for  *%@*.</target>
         <note/>
       </trans-unit>
       <trans-unit id="These are the default settings." xml:space="preserve">
-        <source>These are the default settings.</source>
+        <source>These are the default settings.</source><target>Dette er standardinnstillingene.</target>
         <note/>
       </trans-unit>
       <trans-unit id="These settings will only affect *%@*." xml:space="preserve">
-        <source>These settings will only affect *%@*.</source>
+        <source>These settings will only affect *%@*.</source><target>Disse innstillingene påvirker kun *%@*.</target>
         <note>Shown in spoiler settings for a particular show</note>
       </trans-unit>
       <trans-unit id="Though it was written by me, Callsheet wouldn't be possible without the efforts of the following people:" xml:space="preserve">
-        <source>Though it was written by me, Callsheet wouldn't be possible without the efforts of the following people:</source>
+        <source>Though it was written by me, Callsheet wouldn't be possible without the efforts of the following people:</source><target>Selv om den ble laget av meg, ville ikke Callsheet vært mulig uten innsatsen til de følgende personene: </target>
         <note/>
       </trans-unit>
       <trans-unit id="Title, cast, or crew" xml:space="preserve">
-        <source>Title, cast, or crew</source>
+        <source>Title, cast, or crew</source><target>Tittel, medvirkende eller besetning</target>
         <note>Main search prompt on the bottom bar!</note>
       </trans-unit>
       <trans-unit id="Total runtime %@" xml:space="preserve">
-        <source>Total runtime %@</source>
+        <source>Total runtime %@</source><target>Total spilletid %@</target>
         <note>Shown in a popover when looking at a TV season</note>
       </trans-unit>
       <trans-unit id="Transaction" xml:space="preserve">
-        <source>Transaction</source>
+        <source>Transaction</source><target>Transaksjon</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Trial Period" xml:space="preserve">
-        <source>Trial Period</source>
+        <source>Trial Period</source><target>Prøveperiode</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Trivia" xml:space="preserve">
-        <source>Trivia</source>
+        <source>Trivia</source><target>Trivia</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Unfortunately, [The Movie Database](https://www.themoviedb.org/) does not yet support doing a union search for shows. I've asked them to add it; we'll see what happens!" xml:space="preserve">
-        <source>Unfortunately, [The Movie Database](https://www.themoviedb.org/) does not yet support doing a union search for shows. I've asked them to add it; we'll see what happens!</source>
+        <source>Unfortunately, [The Movie Database](https://www.themoviedb.org/) does not yet support doing a union search for shows. I've asked them to add it; we'll see what happens!</source><target>Dessverre støtter [The Movie Database] (https://www.themoviedb.org/) ennå ikke unionssøk etter serier. Jeg har bedt dem om å legge det til; vi får se hva som skjer!</target>
         <note/>
       </trans-unit>
       <trans-unit id="Unknown" xml:space="preserve">
-        <source>Unknown</source>
+        <source>Unknown</source><target>Ukjent</target>
         <note/>
       </trans-unit>
       <trans-unit id="Unlimited searches" xml:space="preserve">
-        <source>Unlimited searches</source>
+        <source>Unlimited searches</source><target>Ubegrensede søk</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Upcoming" xml:space="preserve">
-        <source>Upcoming</source>
+        <source>Upcoming</source><target>Kommende</target>
         <note>Header for titles a person will be in, but have not been released yet</note>
       </trans-unit>
       <trans-unit id="Upgraded" xml:space="preserve">
-        <source>Upgraded</source>
+        <source>Upgraded</source><target>Oppgradert</target>
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="User Interface" xml:space="preserve">
-        <source>User Interface</source>
+        <source>User Interface</source><target>Brukergrensesnitt</target>
         <note>Header in Persnickety Preferences</note>
       </trans-unit>
       <trans-unit id="Waiting for approval…" xml:space="preserve">
-        <source>Waiting for approval…</source>
+        <source>Waiting for approval…</source><target>Venter på godkjennelse…</target>
         <note>Shown when waiting for a purchase to be approved (probably by a parent)</note>
       </trans-unit>
       <trans-unit id="Watch in:" xml:space="preserve">
-        <source>Watch in:</source>
+        <source>Watch in:</source><target>Se i:</target>
         <note>Shown when choosing a country to use for Where to Watch (short version)</note>
       </trans-unit>
       <trans-unit id="Website" xml:space="preserve">
-        <source>Website</source>
+        <source>Website</source><target>Nettside</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="What was that thing I looked up yesterday?" xml:space="preserve">
-        <source>What was that thing I looked up yesterday?</source>
+        <source>What was that thing I looked up yesterday?</source><target>Hva var det jeg søkte på i går?</target>
         <note>Subtitle for "Search history"; shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Where to Watch" xml:space="preserve">
-        <source>Where to Watch</source>
+        <source>Where to Watch</source><target>Hvor man kan se</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Which browser to use to open external links." xml:space="preserve">
-        <source>Which browser to use to open external links.</source>
+        <source>Which browser to use to open external links.</source><target>Hvilken nettleser skal brukes for å åpne eksterne lenker.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Which quick access link is shown." xml:space="preserve">
-        <source>Which quick access link is shown.</source>
+        <source>Which quick access link is shown.</source><target>Hvilken hurtigtilgangslenke vises.</target>
         <note>Shown as a subtitle for a row on Settings</note>
       </trans-unit>
       <trans-unit id="Why not shows?" xml:space="preserve">
-        <source>Why not shows?</source>
+        <source>Why not shows?</source><target>Hvorfor ikke serier?</target>
         <note>Shown at the bottom of the "what movies are both of these actors in?" screen</note>
       </trans-unit>
       <trans-unit id="Wikipedia" xml:space="preserve">
-        <source>Wikipedia</source>
+        <source>Wikipedia</source><target>Wikipedia</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Will NOT renew" xml:space="preserve">
-        <source>Will NOT renew</source>
+        <source>Will NOT renew</source><target>Blir IKKE fornyet</target>
         <note>Shown in a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Will renew" xml:space="preserve">
-        <source>Will renew</source>
+        <source>Will renew</source><target>Blir fornyet</target>
         <note>Shown in a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="With a subscription, you get:" xml:space="preserve">
-        <source>With a subscription, you get:</source>
+        <source>With a subscription, you get:</source><target>Med et abonnement, får du tilgang til:</target>
         <note/>
       </trans-unit>
       <trans-unit id="You Can Help" xml:space="preserve">
-        <source>You Can Help</source>
+        <source>You Can Help</source><target>Du kan bidra</target>
         <note>Title shown when trying to upsell users to more-expensive subscriptions</note>
       </trans-unit>
       <trans-unit id="You can be second! That’s pretty great!" xml:space="preserve">
-        <source>You can be second! That’s pretty great!</source>
+        <source>You can be second! That’s pretty great!</source><target>Du kan bli nummer to! Det er ganske flott!</target>
         <note>Shown to try to encourage the user to rate the app</note>
       </trans-unit>
       <trans-unit id="You can be the first! Don’t be shy!" xml:space="preserve">
-        <source>You can be the first! Don’t be shy!</source>
+        <source>You can be the first! Don’t be shy!</source><target>Du kan bli den første! Ikke vær sjenert!</target>
         <note>Shown to try to encourage the user to rate the app</note>
       </trans-unit>
       <trans-unit id="You don't seem to have a subscription. 🤨" xml:space="preserve">
-        <source>You don't seem to have a subscription. 🤨</source>
+        <source>You don't seem to have a subscription. 🤨</source><target>Du ser ikke ut til å ha et abonnement. 🤨</target>
         <note/>
       </trans-unit>
       <trans-unit id="You have used all your free searches. Subscribe for unlimited searches." xml:space="preserve">
-        <source>You have used all your free searches. Subscribe for unlimited searches.</source>
+        <source>You have used all your free searches. Subscribe for unlimited searches.</source><target>Du har brukt opp alle dine gratis søk. Abonner for ubegrenset antall søk.</target>
         <note/>
       </trans-unit>
       <trans-unit id="You may know them from" xml:space="preserve">
-        <source>You may know them from</source>
+        <source>You may know them from</source><target>Du kjenner dem kanskje fra</target>
         <note>Header shown for people</note>
       </trans-unit>
       <trans-unit id="Your favorite characters finally get married." xml:space="preserve">
-        <source>Your favorite characters finally get married.</source>
+        <source>Your favorite characters finally get married.</source><target>Favorittkarakterene dine gifter seg endelig.</target>
         <note>A fake summary shown when demonstrating hiding spoilers</note>
       </trans-unit>
       <trans-unit id="Your purchase is still pending. Please wait for it to be approved." xml:space="preserve">
-        <source>Your purchase is still pending. Please wait for it to be approved.</source>
+        <source>Your purchase is still pending. Please wait for it to be approved.</source><target>Kjøpet ditt er fortsatt under behandling. Vennligst vent til det blir godkjent.</target>
         <note>Shown when a a purchase needs to be approved; likely a child needs a parent to approve it</note>
       </trans-unit>
       <trans-unit id="Your subscription **will not** auto-renew" xml:space="preserve">
-        <source>Your subscription **will not** auto-renew</source>
+        <source>Your subscription **will not** auto-renew</source><target>Abonnementet ditt blir **ikke** fornyet automatisk.</target>
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription **will** auto-renew" xml:space="preserve">
-        <source>Your subscription **will** auto-renew</source>
+        <source>Your subscription **will** auto-renew</source><target>Abonnementet ditt **blir** fornyet automatisk.</target>
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="`%@` is unimplemented" xml:space="preserve">
-        <source>`%@` is unimplemented</source>
+        <source>`%@` is unimplemented</source><target/>
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="per %@" xml:space="preserve">
-        <source>per %@</source>
+        <source>per %@</source><target>per %@</target>
         <note>cost per period; ie "per month" or "per year"</note>
       </trans-unit>
       <trans-unit id="pin" xml:space="preserve">
-        <source>pin</source>
+        <source>pin</source><target>fest</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
@@ -1214,11 +1215,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="visionOS does not support changing icons yet." xml:space="preserve">
-        <source>visionOS does not support changing icons yet.</source>
+        <source>visionOS does not support changing icons yet.</source><target>visionOS støtter ikke å endre ikoner enda.</target>
         <note>Subtitle for the App Icon row in Settings on visionOS</note>
       </trans-unit>
       <trans-unit id="years old" xml:space="preserve">
-        <source>years old</source>
+        <source>years old</source><target>år</target>
         <note>Shown as a header for a year in a person's filmography; "52 - 53 years old</note>
       </trans-unit>
       <trans-unit id="© 2023%@ Limitliss LLC" xml:space="preserve">
@@ -1226,11 +1227,11 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="🤝" xml:space="preserve">
-        <source>🤝</source>
+        <source>🤝</source><target>🤝</target>
         <note/>
       </trans-unit>
       <trans-unit id="🤷‍♂️" xml:space="preserve">
-        <source>🤷‍♂️</source>
+        <source>🤷‍♂️</source><target>🤷‍♂️</target>
         <note/>
       </trans-unit>
     </body>

--- a/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
+++ b/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
@@ -6,23 +6,23 @@
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>Callsheet</source>
+        <source>Callsheet</source><target>Callsheet</target>
         <note>Bundle display name</note>
       </trans-unit>
       <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>Callsheet</source>
+        <source>Callsheet</source><target>Callsheet</target>
         <note>Bundle name</note>
       </trans-unit>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
-        <source>If Callsheet can use your local network, it may be able to show links to what you're currently watching on the main screen. Enabling local network usage is completely optional. No data about your network is sent off your device.</source>
+        <source>If Callsheet can use your local network, it may be able to show links to what you're currently watching on the main screen. Enabling local network usage is completely optional. No data about your network is sent off your device.</source><target>Hvis Callsheet kan bruke det lokale nettverket ditt, kan det hende at det kan vise lenker til det du ser på for øyeblikket på hovedskjermen. Det er helt valgfritt å aktivere lokal nettverksbruk. Ingen data om nettverket ditt sendes fra enheten din.</target>
         <note>Privacy - Local Network Usage Description</note>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
-        <source>Search</source>
+        <source>Search</source><target>Søk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Title, cast, or crew" xml:space="preserve">
-        <source>Title, cast, or crew</source>
+        <source>Title, cast, or crew</source><target>Tittel, medvirkende eller besetning</target>
         <note/>
       </trans-unit>
     </body>
@@ -1015,7 +1015,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Subscribers can change the app’s icon." xml:space="preserve">
-        <source>Subscribers can change the app’s icon.</source><target>Abonnementer kan endre ikonet på appen.</target>
+        <source>Subscribers can change the app’s icon.</source><target>Abonnenter kan endre ikonet på appen.</target>
         <note>Subtitle for the App Icon row in Settings</note>
       </trans-unit>
       <trans-unit id="Subscription Status" xml:space="preserve">

--- a/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
+++ b/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
@@ -137,11 +137,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="Add Pin" xml:space="preserve">
-        <source>Add Pin</source><target>Fest</target>
+        <source>Add Pin</source><target>Lett til merkelapp</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add pin" xml:space="preserve">
-        <source>Add pin</source><target>Fest</target>
+        <source>Add pin</source><target>Legg til merkelapp</target>
         <note/>
       </trans-unit>
       <trans-unit id="Ages" xml:space="preserve">
@@ -635,7 +635,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="No TV show pins found." xml:space="preserve">
-        <source>No TV show pins found.</source><target>Ingen festede TV-serier ble funnet. </target>
+        <source>No TV show pins found.</source><target>Ingen merkede TV-serier ble funnet. </target>
         <note/>
       </trans-unit>
       <trans-unit id="No credits found." xml:space="preserve">
@@ -647,7 +647,7 @@
         <note>Shown when there's no data for new movies / new shows / etc</note>
       </trans-unit>
       <trans-unit id="No movie pins found." xml:space="preserve">
-        <source>No movie pins found.</source><target>Ingen festede filmer ble funnet</target>
+        <source>No movie pins found.</source><target>Ingen merkede filmer ble funnet</target>
         <note/>
       </trans-unit>
       <trans-unit id="No override" xml:space="preserve">
@@ -663,11 +663,11 @@
         <note>Shown when searching a list of credits, but no matches were found</note>
       </trans-unit>
       <trans-unit id="No people pins found." xml:space="preserve">
-        <source>No people pins found.</source><target>Ingen festede personer ble funnet.</target>
+        <source>No people pins found.</source><target>Ingen merkede personer ble funnet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No pinned items found." xml:space="preserve">
-        <source>No pinned items found.</source><target>Ingen festede elementer ble funnet.</target>
+        <source>No pinned items found.</source><target>Ingen merkede elementer ble funnet.</target>
         <note>Shown on the home screen</note>
       </trans-unit>
       <trans-unit id="No providers found." xml:space="preserve">
@@ -739,23 +739,23 @@
         <note>Picker label for accessibility purposes, in Where to Watch</note>
       </trans-unit>
       <trans-unit id="Pin" xml:space="preserve">
-        <source>Pin</source><target>Fest</target>
+        <source>Pin</source><target>Merk</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="Pin Type" xml:space="preserve">
-        <source>Pin Type</source><target>Type element</target>
+        <source>Pin Type</source><target>Type merkelapp</target>
         <note>Shown in the list of pins screen</note>
       </trans-unit>
       <trans-unit id="Pin your favorites for quick access." xml:space="preserve">
-        <source>Pin your favorites for quick access.</source><target>Fest favorittene dine for raskere tilgang.</target>
+        <source>Pin your favorites for quick access.</source><target>Merk favorittene dine for raskere tilgang.</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
-        <source>Pinned Items</source><target>Festede Elementer</target>
+        <source>Pinned Items</source><target>Merkelapper</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pinned items" xml:space="preserve">
-        <source>Pinned items</source><target>Festede elementer</target>
+        <source>Pinned items</source><target>Merkelapper</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Plans:" xml:space="preserve">
@@ -859,11 +859,11 @@
         <note>When a TV episode or movie will be released</note>
       </trans-unit>
       <trans-unit id="Remove Pin" xml:space="preserve">
-        <source>Remove Pin</source><target>Fjern festet element</target>
+        <source>Remove Pin</source><target>Fjern merkelapp</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove pin" xml:space="preserve">
-        <source>Remove pin</source><target>Fjern festet element</target>
+        <source>Remove pin</source><target>Fjern merkelapp</target>
         <note/>
       </trans-unit>
       <trans-unit id="Request Refund" xml:space="preserve">
@@ -1207,11 +1207,11 @@
         <note>cost per period; ie "per month" or "per year"</note>
       </trans-unit>
       <trans-unit id="pin" xml:space="preserve">
-        <source>pin</source><target>fest</target>
+        <source>pin</source><target>merk</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
-        <source>pinned items</source><target>festede elementer</target>
+        <source>pinned items</source><target>merkelapper</target>
         <note/>
       </trans-unit>
       <trans-unit id="visionOS does not support changing icons yet." xml:space="preserve">

--- a/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
+++ b/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
@@ -137,11 +137,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="Add Pin" xml:space="preserve">
-        <source>Add Pin</source><target>Lett til merkelapp</target>
+        <source>Add Pin</source><target>Fest</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add pin" xml:space="preserve">
-        <source>Add pin</source><target>Legg til merkelapp</target>
+        <source>Add pin</source><target>Fest</target>
         <note/>
       </trans-unit>
       <trans-unit id="Ages" xml:space="preserve">
@@ -635,7 +635,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="No TV show pins found." xml:space="preserve">
-        <source>No TV show pins found.</source><target>Ingen merkede TV-serier ble funnet. </target>
+        <source>No TV show pins found.</source><target>Ingen festede TV-serier ble funnet. </target>
         <note/>
       </trans-unit>
       <trans-unit id="No credits found." xml:space="preserve">
@@ -647,7 +647,7 @@
         <note>Shown when there's no data for new movies / new shows / etc</note>
       </trans-unit>
       <trans-unit id="No movie pins found." xml:space="preserve">
-        <source>No movie pins found.</source><target>Ingen merkede filmer ble funnet</target>
+        <source>No movie pins found.</source><target>Ingen festede filmer ble funnet</target>
         <note/>
       </trans-unit>
       <trans-unit id="No override" xml:space="preserve">
@@ -663,11 +663,11 @@
         <note>Shown when searching a list of credits, but no matches were found</note>
       </trans-unit>
       <trans-unit id="No people pins found." xml:space="preserve">
-        <source>No people pins found.</source><target>Ingen merkede personer ble funnet.</target>
+        <source>No people pins found.</source><target>Ingen festede personer ble funnet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No pinned items found." xml:space="preserve">
-        <source>No pinned items found.</source><target>Ingen merkede elementer ble funnet.</target>
+        <source>No pinned items found.</source><target>Ingen festede elementer ble funnet</target>
         <note>Shown on the home screen</note>
       </trans-unit>
       <trans-unit id="No providers found." xml:space="preserve">
@@ -739,23 +739,23 @@
         <note>Picker label for accessibility purposes, in Where to Watch</note>
       </trans-unit>
       <trans-unit id="Pin" xml:space="preserve">
-        <source>Pin</source><target>Merk</target>
+        <source>Pin</source><target>Fest</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="Pin Type" xml:space="preserve">
-        <source>Pin Type</source><target>Type merkelapp</target>
+        <source>Pin Type</source><target>Type element</target>
         <note>Shown in the list of pins screen</note>
       </trans-unit>
       <trans-unit id="Pin your favorites for quick access." xml:space="preserve">
-        <source>Pin your favorites for quick access.</source><target>Merk favorittene dine for raskere tilgang.</target>
+        <source>Pin your favorites for quick access.</source><target>Fest favorittene dine for raskere tilgang.</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
-        <source>Pinned Items</source><target>Merkelapper</target>
+        <source>Pinned Items</source><target>Festede elementer</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pinned items" xml:space="preserve">
-        <source>Pinned items</source><target>Merkelapper</target>
+        <source>Pinned items</source><target>Festede elementer</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Plans:" xml:space="preserve">
@@ -859,11 +859,11 @@
         <note>When a TV episode or movie will be released</note>
       </trans-unit>
       <trans-unit id="Remove Pin" xml:space="preserve">
-        <source>Remove Pin</source><target>Fjern merkelapp</target>
+        <source>Remove Pin</source><target>Løsne</target>
         <note/>
       </trans-unit>
       <trans-unit id="Remove pin" xml:space="preserve">
-        <source>Remove pin</source><target>Fjern merkelapp</target>
+        <source>Remove pin</source><target>Løsne</target>
         <note/>
       </trans-unit>
       <trans-unit id="Request Refund" xml:space="preserve">
@@ -1207,11 +1207,11 @@
         <note>cost per period; ie "per month" or "per year"</note>
       </trans-unit>
       <trans-unit id="pin" xml:space="preserve">
-        <source>pin</source><target>merk</target>
+        <source>pin</source><target>fest</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
-        <source>pinned items</source><target>merkelapper</target>
+        <source>pinned items</source><target>festede elementer</target>
         <note/>
       </trans-unit>
       <trans-unit id="visionOS does not support changing icons yet." xml:space="preserve">

--- a/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
+++ b/CallsheetLocalizations/nb-NO.xcloc/Localized Contents/nb-NO.xliff
@@ -129,7 +129,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="A few more free ones please?" xml:space="preserve">
-        <source>A few more free ones please?</source><target>Et par ekstra gratissøk, vær så snill?</target>
+        <source>A few more free ones please?</source><target>Et par ekstra gratis søk, vær så snill?</target>
         <note>Shown on the "Additional options" purchasing screen, offering the user five more free searches</note>
       </trans-unit>
       <trans-unit id="About Callsheet" xml:space="preserve">
@@ -415,11 +415,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="Free searches remaining" xml:space="preserve">
-        <source>Free searches remaining</source><target>Gjenstående gratissøk</target>
+        <source>Free searches remaining</source><target>Gjenstående gratis søk</target>
         <note/>
       </trans-unit>
       <trans-unit id="Free stuff doesn't last forever." xml:space="preserve">
-        <source>Free stuff doesn't last forever.</source><target>Gratis ting varer ikke evig.</target>
+        <source>Free stuff doesn't last forever.</source><target>Ting som er gratis varer ikke evig.</target>
         <note>Subtitle for "Unlimited searches"; shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Free, but you can only ask once. 😏" xml:space="preserve">


### PR DESCRIPTION
Adds Norwegian (nb-NO) localization to Callsheet. 

- I'd like to note that in the cases where there are two entries, one where each word is capitalized, and one where it isn't, I chose to always _only_ capitalize the first letter as [that's the only valid approach in Norwegian](https://www.sprakradet.no/svardatabase/sporsmal-og-svar/bruk-av-stor-forbokstav-i-overskrifter-og-titler/). 
- ~The translation of "pins" also ended up being more akin to "labels", as there aren't any good translations that convey the same imagery. I can take another pass and change this translation to be more in line with the English variant, but it does read a fair bit worse in my opinion.~ -> Opted to change this after all, using a similar pattern to what WhatsApp does in Norwegian. 