### PR TITLE
1st pass for Spanish translation in testFlight App

### DIFF
--- a/AppStore/Spanish/Description.iOS.txt
+++ b/AppStore/Spanish/Description.iOS.txt
@@ -1,28 +1,28 @@
-¿Alguna vez te has preguntado "¿quién es ese actor?", o tal vez "¿cuándo se estrenó esta película?", o "¿cuál fue el título de ese episodio de ese programa que amo"? Quizás eres un aficionado al cine y te preguntas "¿cuántos años tenía esta persona cuando se estrenó esta película?".
+¿Alguna vez te has preguntado "¿quién es ese actor?", o tal vez "¿cuándo se estrenó esta película?", o "¿cuál fue el título de ese episodio de esa serie que adoro"? Quizás eres un aficionado al cine y te preguntas "¿cuántos años tenía esta persona cuando se estrenó esta película?".
 
 ¿Has querido responder esas preguntas sin que te pidan iniciar sesión cada cinco segundos? ¿Sin anuncios y sin videos que se reproducen automáticamente? ¿Sin depender de un conglomerado multinacional que intenta venderte cosas?
 
 Te encantará Callsheet.
 
-Callsheet es la mejor manera de buscar rápidamente información sobre el reparto y el equipo de series y películas. Respeta tu tiempo, no intenta venderte cosas que no necesitas y está diseñado para responder tus preguntas de manera fácil y rápida.
+Callsheet es la mejor manera de buscar rápidamente información sobre el reparto y el equipo de series y películas. Callsheet respeta tu tiempo, no intenta venderte cosas que no necesitas y está diseñado para responder tus preguntas de manera fácil y rápida.
 
-Callsheet también tiene algunas características novedosas que tu aplicación de base de datos favorita anterior no tiene:
+Callsheet también tiene algunas características novedosas que tu anterior aplicación favorita de películas y series no tiene:
 
-• Evita espoilers cuando veas series ocultando opcionalmente los nombres de los personajes, el número de episodios, los títulos de los episodios o las miniaturas de los mismos. No arruines la sorpresa de la identidad secreta de un personaje o de que dejará la serie, ocultando esas pistas.
+• Evita espoilers cuando veas series ocultando (opcionalmente) los nombres de los personajes, el número de episodios, los títulos de los episodios o las miniaturas de los mismos. No arruines la sorpresa de la identidad secreta de un personaje o de que va a dejar la serie, ocultando esas pistas.
 • Acceso rápido a Curiosidades, Wikipedia, Guía para Padres y Donde Ver (proporcionado por JustWatch).
-• Fija programas, películas o personas para acceder rápidamente.
-• Encuentra cosas que has buscado antes utilizando Búsquedas Recientes o Historial de Búsqueda.
+• Fija programas, películas o personas para acceder a ellos rápidamente.
+• Encuentra cosas que has buscado antes utilizando "Búsquedas Recientes" o "Historial de Búsqueda".
 • Ve fácilmente la edad de los miembros del reparto cuando *se estrenó una película* directamente en el reparto.
 • Ve fácilmente la edad de una persona para cada entrada en su filmografía.
 • Ve fácilmente la altura de los actores (cuando sea posible).
 • Soporte para Modo Oscuro.
 • Soporte para VoiceOver.
 • Íconos de aplicación alternativos para suscriptores.
-• Integración automática y sin inicio de sesión con la maravillosa aplicación Channels.
-• Integración experimental y sin inicio de sesión con Plex.
+• Integración automática (y sin inicio de sesión) con la maravillosa aplicación Channels.
+• Integración experimental (y sin inicio de sesión) con Plex.
 
-Callsheet está escrito por una sola persona que REALMENTE se preocupa por respetar tu tiempo. Callsheet está diseñado para que puedas entrar, encontrar lo que necesitas sin complicaciones y luego volver a la película o programa que realmente te importa. Sin distracciones y sin solicitudes para iniciar sesión.
+Callsheet está desarrollado por una sola persona que REALMENTE se preocupa por respetar tu tiempo. Callsheet está diseñado para que puedas entrar, encontrar lo que necesitas sin complicaciones y luego volver a la película o serie, que es lo que realmente te importa. Sin distracciones y sin solicitudes para iniciar sesión.
 
-Callsheet ofrece 20 búsquedas gratis y luego requiere una suscripción. Todas las suscripciones incluyen una prueba gratuita de una semana. Admiten En Familia.
+Callsheet ofrece 20 búsquedas gratis y después requiere una suscripción. Todas las suscripciones incluyen una prueba gratuita de una semana. Admiten En Familia.
 
-Prueba Callsheet. No creerás lo mejor que es, en comparación con la aplicación que estabas usando antes.
+Prueba Callsheet. No creerás lo buena que es en comparación a la aplicación que estabas usando antes.

--- a/AppStore/Spanish/Description.visionOS.txt
+++ b/AppStore/Spanish/Description.visionOS.txt
@@ -17,7 +17,6 @@ Callsheet también tiene algunas características novedosas que tu anterior apli
 • Ve fácilmente la altura de los actores (cuando sea posible).
 • Soporte para Modo Oscuro.
 • Soporte para VoiceOver.
-• Íconos de aplicación alternativos para suscriptores.
 • Integración automática (y sin inicio de sesión) con la maravillosa aplicación Channels.
 • Integración experimental (y sin inicio de sesión) con Plex.
 

--- a/AppStore/Spanish/Description.visionOS.txt
+++ b/AppStore/Spanish/Description.visionOS.txt
@@ -1,28 +1,28 @@
-¿Alguna vez te has preguntado "¿quién es ese actor?", o tal vez "¿cuándo se estrenó esta película?", o "¿cuál fue el título de ese episodio de ese programa que amo"? Quizás eres un aficionado al cine y te preguntas "¿cuántos años tenía esta persona cuando se estrenó esta película?".
+¿Alguna vez te has preguntado "¿quién es ese actor?", o tal vez "¿cuándo se estrenó esta película?", o "¿cuál fue el título de ese episodio de esa serie que adoro"? Quizás eres un aficionado al cine y te preguntas "¿cuántos años tenía esta persona cuando se estrenó esta película?".
 
 ¿Has querido responder esas preguntas sin que te pidan iniciar sesión cada cinco segundos? ¿Sin anuncios y sin videos que se reproducen automáticamente? ¿Sin depender de un conglomerado multinacional que intenta venderte cosas?
 
 Te encantará Callsheet.
 
-Callsheet es la mejor manera de buscar rápidamente información sobre el reparto y el equipo de series y películas. Respeta tu tiempo, no intenta venderte cosas que no necesitas y está diseñado para responder tus preguntas de manera fácil y rápida.
+Callsheet es la mejor manera de buscar rápidamente información sobre el reparto y el equipo de series y películas. Callsheet respeta tu tiempo, no intenta venderte cosas que no necesitas y está diseñado para responder tus preguntas de manera fácil y rápida.
 
-Callsheet también tiene algunas características novedosas que tu aplicación de base de datos favorita anterior no tiene:
+Callsheet también tiene algunas características novedosas que tu anterior aplicación favorita de películas y series no tiene:
 
-• Evita espoilers cuando veas series ocultando opcionalmente los nombres de los personajes, el número de episodios, los títulos de los episodios o las miniaturas de los mismos. No arruines la sorpresa de la identidad secreta de un personaje o de que dejará la serie, ocultando esas pistas.
+• Evita espoilers cuando veas series ocultando (opcionalmente) los nombres de los personajes, el número de episodios, los títulos de los episodios o las miniaturas de los mismos. No arruines la sorpresa de la identidad secreta de un personaje o de que va a dejar la serie, ocultando esas pistas.
 • Acceso rápido a Curiosidades, Wikipedia, Guía para Padres y Donde Ver (proporcionado por JustWatch).
-• Fija programas, películas o personas para acceder rápidamente.
-• Encuentra cosas que has buscado antes utilizando Búsquedas Recientes o Historial de Búsqueda.
+• Fija programas, películas o personas para acceder a ellos rápidamente.
+• Encuentra cosas que has buscado antes utilizando "Búsquedas Recientes" o "Historial de Búsqueda".
 • Ve fácilmente la edad de los miembros del reparto cuando *se estrenó una película* directamente en el reparto.
 • Ve fácilmente la edad de una persona para cada entrada en su filmografía.
 • Ve fácilmente la altura de los actores (cuando sea posible).
 • Soporte para Modo Oscuro.
 • Soporte para VoiceOver.
 • Íconos de aplicación alternativos para suscriptores.
-• Integración automática y sin inicio de sesión con la maravillosa aplicación Channels.
-• Integración experimental y sin inicio de sesión con Plex.
+• Integración automática (y sin inicio de sesión) con la maravillosa aplicación Channels.
+• Integración experimental (y sin inicio de sesión) con Plex.
 
-Callsheet está escrito por una sola persona que REALMENTE se preocupa por respetar tu tiempo. Callsheet está diseñado para que puedas entrar, encontrar lo que necesitas sin complicaciones y luego volver a la película o programa que realmente te importa. Sin distracciones y sin solicitudes para iniciar sesión.
+Callsheet está desarrollado por una sola persona que REALMENTE se preocupa por respetar tu tiempo. Callsheet está diseñado para que puedas entrar, encontrar lo que necesitas sin complicaciones y luego volver a la película o serie, que es lo que realmente te importa. Sin distracciones y sin solicitudes para iniciar sesión.
 
-Callsheet ofrece 20 búsquedas gratis y luego requiere una suscripción. Todas las suscripciones incluyen una prueba gratuita de una semana. Admiten En Familia.
+Callsheet ofrece 20 búsquedas gratis y después requiere una suscripción. Todas las suscripciones incluyen una prueba gratuita de una semana. Admiten En Familia.
 
-Prueba Callsheet. No creerás lo mejor que es, en comparación con la aplicación que estabas usando antes.
+Prueba Callsheet. No creerás lo buena que es en comparación a la aplicación que estabas usando antes.

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="Be like the many other beautiful people who have rated this version." xml:space="preserve">
         <source>Be like the many other beautiful people who have rated this version.</source>
-        <target state="translated">Se como muchas de las bellisimas personas que han valorado esta versión.</target>
+        <target state="translated">Sé como muchas de las bellisimas personas que han valorado esta versión.</target>
         <note>Shown to try to encourage the user to rate the app</note>
       </trans-unit>
       <trans-unit id="Began Airing" xml:space="preserve">
@@ -324,7 +324,7 @@
       </trans-unit>
       <trans-unit id="Choose spoiler-risky things to hide by default." xml:space="preserve">
         <source>Choose spoiler-risky things to hide by default.</source>
-        <target state="translated">Elige la cantidad de espóiler que ocultar por defecto</target>
+        <target state="translated">Elige la cantidad de espoilers que ocultar para todas las series</target>
         <note>Subtitle for a row in Settings</note>
       </trans-unit>
       <trans-unit id="Clear" xml:space="preserve">
@@ -389,7 +389,7 @@
       </trans-unit>
       <trans-unit id="Credits Lists" xml:space="preserve">
         <source>Credits Lists</source>
-        <target state="translated">Lista de creditos</target>
+        <target state="translated">Lista de créditos</target>
         <note>Persnickety Preferences header</note>
       </trans-unit>
       <trans-unit id="Crew" xml:space="preserve">
@@ -414,7 +414,7 @@
       </trans-unit>
       <trans-unit id="Default Spoiler Settings" xml:space="preserve">
         <source>Default Spoiler Settings</source>
-        <target state="translated">Ajustes de espóiler por defecto</target>
+        <target state="translated">Ajustes de espoilers por defecto</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete recent searches" xml:space="preserve">
@@ -494,7 +494,7 @@
       </trans-unit>
       <trans-unit id="Feedback emails are lovely to read!" xml:space="preserve">
         <source>Feedback emails are lovely to read!</source>
-        <target state="translated">Es maravilloso leer comentarios por correo electrónico</target>
+        <target state="translated">Recibir emails con comentarios o sugerencias es hermoso</target>
         <note>Shown in Settings to try to get users to rate the app</note>
       </trans-unit>
       <trans-unit id="Find a way to watch in:" xml:space="preserve">
@@ -516,12 +516,12 @@
       </trans-unit>
       <trans-unit id="For Where to Watch." xml:space="preserve">
         <source>For Where to Watch.</source>
-        <target state="translated">para Donde Ver</target>
+        <target state="translated">Para _Donde Ver_</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="For new &amp; popular media." xml:space="preserve">
         <source>For new &amp; popular media.</source>
-        <target state="translated">para Nuevo y Popular</target>
+        <target state="translated">Para _Nuevo y Popular_</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Free Trial" xml:space="preserve">
@@ -651,7 +651,7 @@
       </trans-unit>
       <trans-unit id="If you play something using [Channels](https://getchannels.com/) or [Plex](https://plex.tv/) on another device, Callsheet can display that show or movie at the top of the Discover screen." xml:space="preserve">
         <source>If you play something using [Channels](https://getchannels.com/) or [Plex](https://plex.tv/) on another device, Callsheet can display that show or movie at the top of the Discover screen.</source>
-        <target state="translated">Si reproduces algo usando [Channels](https://getchannels.com/) o [Plex](https://plex.tv/) en otro dispositivo. Callsheet puede mostrar esa serue o película al principio de la pantalla Descubrir.</target>
+        <target state="translated">Si reproduces algo usando [Channels](https://getchannels.com/) o [Plex](https://plex.tv/) en otro dispositivo, Callsheet puede mostrar esa serie o película en la pantalla _Descubrir_.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Image" xml:space="preserve">
@@ -696,12 +696,12 @@
       </trans-unit>
       <trans-unit id="Language Override" xml:space="preserve">
         <source>Language Override</source>
-        <target state="translated">Invalidar Idioma</target>
+        <target state="translated">Ignorar Idioma</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Learn about the people behind Callsheet." xml:space="preserve">
         <source>Learn about the people behind Callsheet.</source>
-        <target state="translated">Conoce a la gente detras de Callsheet</target>
+        <target state="translated">Conoce a la gente que hay detrás de Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Lived" xml:space="preserve">
@@ -766,7 +766,7 @@
       </trans-unit>
       <trans-unit id="Movies and TV shows will show one link for quick access. The others are available in the More menu." xml:space="preserve">
         <source>Movies and TV shows will show one link for quick access. The others are available in the More menu.</source>
-        <target state="translated">Las películas y las series mostraran un enlace rápido. Las demas estaran disponibles en el menú Más</target>
+        <target state="translated">Las películas y las series mostraran un enlace para acceder rápidamente. Las otras opciones estaran disponibles en el menú Más</target>
         <note/>
       </trans-unit>
       <trans-unit id="Movies featuring" xml:space="preserve">
@@ -916,7 +916,7 @@
       </trans-unit>
       <trans-unit id="Other settings for more _particular_ users." xml:space="preserve">
         <source>Other settings for more _particular_ users.</source>
-        <target state="translated">Otros ajustes para usuarios más _particulaesr_.</target>
+        <target state="translated">Otros ajustes para usuarios más _particulares_.</target>
         <note>Subtitle for Persnickety Preferences in Settings</note>
       </trans-unit>
       <trans-unit id="Parental Guidance" xml:space="preserve">
@@ -961,12 +961,12 @@
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
         <source>Pinned Items</source>
-        <target state="translated">Elementos con Pin</target>
+        <target state="translated">Elementos Fijados</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pinned items" xml:space="preserve">
         <source>Pinned items</source>
-        <target state="translated">Elementos con pin</target>
+        <target state="translated">Elementos fijados</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Plans:" xml:space="preserve">
@@ -1011,12 +1011,12 @@
       </trans-unit>
       <trans-unit id="Prevent giving away spoilers by choosing to redact details." xml:space="preserve">
         <source>Prevent giving away spoilers by choosing to redact details.</source>
-        <target state="translated">Previene espoilers eligiendo ocultar detalles</target>
+        <target state="translated">Evita espoilers eligiendo que detalles ocultar</target>
         <note/>
       </trans-unit>
       <trans-unit id="Preview" xml:space="preserve">
         <source>Preview</source>
-        <target state="translated">Vísta Rápida</target>
+        <target state="translated">Ejemplo</target>
         <note/>
       </trans-unit>
       <trans-unit id="Preview Title" xml:space="preserve">
@@ -1066,7 +1066,7 @@
       </trans-unit>
       <trans-unit id="Rate this version of Callsheet" xml:space="preserve">
         <source>Rate this version of Callsheet</source>
-        <target state="translated">Puntua esta versión de Callsheet</target>
+        <target state="translated">Escribe una reseña o valora esta versión de Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Rating" xml:space="preserve">
@@ -1086,7 +1086,7 @@
       </trans-unit>
       <trans-unit id="Region Override" xml:space="preserve">
         <source>Region Override</source>
-        <target state="translated">Invalidar Region</target>
+        <target state="translated">Ignorar Region</target>
         <note>Shown in Settings</note>
       </trans-unit>
       <trans-unit id="Released" xml:space="preserve">
@@ -1251,12 +1251,12 @@
       </trans-unit>
       <trans-unit id="Show age information within credits lists. Ages are always shown for birth/death dates." xml:space="preserve">
         <source>Show age information within credits lists. Ages are always shown for birth/death dates.</source>
-        <target state="translated">Mostrar edad en los créditos. Las edades siempre se muestran para fechas de nacimiento/muerte</target>
+        <target state="translated">Mostrar la edad en los créditos. Las edades siempre se muestran para fechas de nacimiento o muerte</target>
         <note/>
       </trans-unit>
       <trans-unit id="Show movies, shows, or both in credit lists." xml:space="preserve">
         <source>Show movies, shows, or both in credit lists.</source>
-        <target state="translated">Mostrar películas, series o ambos en los créditos</target>
+        <target state="translated">Mostrar películas, series o ambos en la lista de créditos</target>
         <note>Persnickety Preferences subtitle</note>
       </trans-unit>
       <trans-unit id="Show that you _really_ care" xml:space="preserve">
@@ -1286,7 +1286,7 @@
       </trans-unit>
       <trans-unit id="Spoiler Settings" xml:space="preserve">
         <source>Spoiler Settings</source>
-        <target state="translated">Ajustes de espóiler</target>
+        <target state="translated">Ajustes de espoilers</target>
         <note/>
       </trans-unit>
       <trans-unit id="Spoilers" xml:space="preserve">
@@ -1371,7 +1371,7 @@
       </trans-unit>
       <trans-unit id="Though it was written by me, Callsheet wouldn't be possible without the efforts of the following people:" xml:space="preserve">
         <source>Though it was written by me, Callsheet wouldn't be possible without the efforts of the following people:</source>
-        <target state="translated">Aunque lo desarrollé yo, Callsheet no sería posibles sin los esfuerzos de las siguientes personas:</target>
+        <target state="translated">Aunque ha sido desarrollado sólo por mi, Callsheet no sería posibles sin los esfuerzos de las siguientes personas:</target>
         <note/>
       </trans-unit>
       <trans-unit id="Title, cast, or crew" xml:space="preserve">
@@ -1456,12 +1456,12 @@
       </trans-unit>
       <trans-unit id="Which browser to use to open external links." xml:space="preserve">
         <source>Which browser to use to open external links.</source>
-        <target state="translated">Que navegador uso para abrir los enlaces externos</target>
+        <target state="translated">Que navegador usas para abrir los enlaces externos</target>
         <note/>
       </trans-unit>
       <trans-unit id="Which quick access link is shown." xml:space="preserve">
         <source>Which quick access link is shown.</source>
-        <target state="translated">Que enlace rápido se muestra</target>
+        <target state="translated">Que enlace rápido se muestra de forma principal</target>
         <note>Shown as a subtitle for a row on Settings</note>
       </trans-unit>
       <trans-unit id="Why not shows?" xml:space="preserve">
@@ -1521,7 +1521,7 @@
       </trans-unit>
       <trans-unit id="Your favorite characters finally get married." xml:space="preserve">
         <source>Your favorite characters finally get married.</source>
-        <target state="translated">Tu personaje favorito se casa finalmente</target>
+        <target state="translated">Tu personaje favorito finalmente se casa</target>
         <note>A fake summary shown when demonstrating hiding spoilers</note>
       </trans-unit>
       <trans-unit id="Your purchase is still pending. Please wait for it to be approved." xml:space="preserve">
@@ -1556,7 +1556,7 @@
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
         <source>pinned items</source>
-        <target state="translated">elementos con pin</target>
+        <target state="translated">elementos fijados</target>
         <note/>
       </trans-unit>
       <trans-unit id="visionOS does not support changing icons yet." xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -17,7 +17,7 @@
       </trans-unit>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>If Callsheet can use your local network, it may be able to show links to what you're currently watching on the main screen. Enabling local network usage is completely optional. No data about your network is sent off your device.</source>
-        <target>Si Callsheet puede usar tu red local, puede que pueda mostrar links a lo que estas viendo en este momento en tu pantalla principal. Permtir el acceso a tu red local es totalmente opcional. Ningún dato de tu red saldrá de tu dispositivo. </target>
+        <target>Si Callsheet puede usar tu red local, puede que pueda mostrar links a lo que estas viendo en este momento en tu pantalla principal. Permtir el acceso a tu red local es totalmente opcional. Ningún dato de tu red saldrá de tu dispositivo.</target>
         <note>Privacy - Local Network Usage Description</note>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="Title, cast, or crew" xml:space="preserve">
         <source>Title, cast, or crew</source>
-        <target>Título, reparto o  equipo</target>
+        <target>Título, reparto o equipo</target>
         <note/>
       </trans-unit>
     </body>
@@ -208,7 +208,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Apple Keynote" xml:space="preserve">
-        <source>Apple Keynote</source>
+        <source>Apple Keynote</source><target>Evento de Apple</target>
         <note>Example episode name shown in Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Are you sure?" xml:space="preserve">
@@ -257,7 +257,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Botanist" xml:space="preserve">
-        <source>Botanist</source>
+        <source>Botanist</source><target>Jardinero</target>
         <note>Example role shown in Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Browser" xml:space="preserve">
@@ -452,7 +452,7 @@
       </trans-unit>
       <trans-unit id="Each TV show can have their own settings, set by tapping the `Hide` `Spoilers…` button when looking at a show or episode." xml:space="preserve">
         <source>Each TV show can have their own settings, set by tapping the `Hide` `Spoilers…` button when looking at a show or episode.</source>
-        <target state="translated">Cada serie puede tener sus propios ajustes, pulsa el botón 'Ocultar espoilers...'  cuando busques una serie o episodio.</target>
+        <target state="translated">Cada serie puede tener sus propios ajustes, pulsa el botón 'Ocultar espoilers...' cuando busques una serie o episodio.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Ends at %@" xml:space="preserve">
@@ -549,7 +549,7 @@
       </trans-unit>
       <trans-unit id="Free, but you can only ask once. 😏" xml:space="preserve">
         <source>Free, but you can only ask once. 😏</source>
-        <target state="translated">Gratis, pero sólo puedes pedirlo una vez  😏</target>
+        <target state="translated">Gratis, pero sólo puedes pedirlo una vez 😏</target>
         <note>Subtitle for the "A few more searches please" option on the "Additional options" purchasing screen</note>
       </trans-unit>
       <trans-unit id="Genre" xml:space="preserve">
@@ -1053,7 +1053,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Purchase a subscription" xml:space="preserve">
-        <source>Purchase a subscription</source>
+        <source>Purchase a subscription</source><target>Compra una suscripción</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Purchased" xml:space="preserve">
@@ -1062,7 +1062,7 @@
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Purchasing is unavailable at this time." xml:space="preserve">
-        <source>Purchasing is unavailable at this time.</source>
+        <source>Purchasing is unavailable at this time.</source><target>No es posible realizar compras en este momento.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Purchasing…" xml:space="preserve">
@@ -1077,7 +1077,7 @@
       </trans-unit>
       <trans-unit id="Quickly place emoji on photos — for privacy or fun!" xml:space="preserve">
         <source>Quickly place emoji on photos — for privacy or fun!</source>
-        <target state="translated">Pon emojis en fotos  — Por privacidad o por diversión</target>
+        <target state="translated">Pon emojis en fotos — Por privacidad o por diversión</target>
         <note>MaskerAid subtitle in Settings</note>
       </trans-unit>
       <trans-unit id="Rate this version of Callsheet" xml:space="preserve">
@@ -1141,11 +1141,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="Restore Purchases" xml:space="preserve">
-        <source>Restore Purchases</source>
+        <source>Restore Purchases</source><target>Restaurar compras</target>
         <note>Button title in Settings</note>
       </trans-unit>
       <trans-unit id="Restoring…" xml:space="preserve">
-        <source>Restoring…</source>
+        <source>Restoring…</source><target>Restaurando...</target>
         <note>Button title in Settings when actively restoring a purchase</note>
       </trans-unit>
       <trans-unit id="Reverse sort order" xml:space="preserve">
@@ -1170,7 +1170,7 @@
       </trans-unit>
       <trans-unit id="Same perks as all other plans" xml:space="preserve">
         <source>Same perks as all other plans</source>
-        <target state="translated">Las mismas ventajas  que todos los otros planes</target>
+        <target state="translated">Las mismas ventajas que todos los otros planes</target>
         <note>Shown when trying to sell a subscription</note>
       </trans-unit>
       <trans-unit id="Save" xml:space="preserve">
@@ -1294,7 +1294,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="So sorry!" xml:space="preserve">
-        <source>So sorry!</source>
+        <source>So sorry!</source><target>¡Lo siento!</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Sorry, there was a problem." xml:space="preserve">
@@ -1329,7 +1329,7 @@
       </trans-unit>
       <trans-unit id="Subscribe" xml:space="preserve">
         <source>Subscribe</source>
-        <target state="translated">Suscribete</target>
+        <target state="translated">Suscríbete</target>
         <note/>
       </trans-unit>
       <trans-unit id="Subscribed" xml:space="preserve">
@@ -1494,7 +1494,7 @@
       </trans-unit>
       <trans-unit id="Why not shows?" xml:space="preserve">
         <source>Why not shows?</source>
-        <target state="translated">¡Porqué no hay series?</target>
+        <target state="translated">¿Por qué no hay series?</target>
         <note>Shown at the bottom of the "what movies are both of these actors in?" screen</note>
       </trans-unit>
       <trans-unit id="Wikipedia" xml:space="preserve">
@@ -1538,11 +1538,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="You have %lld day remaining in your trial.|==|plural.one" xml:space="preserve">
-        <source>You have %lld day remaining in your trial.</source>
+        <source>You have %lld day remaining in your trial.</source><target>Queda %lld día en tu prueba</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="You have %lld day remaining in your trial.|==|plural.other" xml:space="preserve">
-        <source>You have %lld days remaining in your trial.</source>
+        <source>You have %lld days remaining in your trial.</source><target>Quedan %lld días en tu prueba</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="You have used all your free searches. Subscribe for unlimited searches." xml:space="preserve">
@@ -1556,12 +1556,13 @@
         <note>Header shown for people</note>
       </trans-unit>
       <trans-unit id="You must have a subscription to use the app." xml:space="preserve">
-        <source>You must have a subscription to use the app.</source>
+        <source>You must have a subscription to use the app.</source><target>Tienes que tener una suscripción para usar la app</target>
         <note>Shown in Settings as a subtitle if you haven't purchased the app</note>
       </trans-unit>
       <trans-unit id="Your %@ will expire on&#10;%@" xml:space="preserve">
         <source>Your %1$@ will expire on
-%2$@</source>
+%2$@</source><target>Tu %1$@ caducará el
+%2$@</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Your favorite characters finally get married." xml:space="preserve">
@@ -1570,7 +1571,7 @@
         <note>A fake summary shown when demonstrating hiding spoilers</note>
       </trans-unit>
       <trans-unit id="Your free trial has expired; you must purchase a subscription to use Callsheet." xml:space="preserve">
-        <source>Your free trial has expired; you must purchase a subscription to use Callsheet.</source>
+        <source>Your free trial has expired; you must purchase a subscription to use Callsheet.</source><target>Tu prueba gratuita ha caducado; tienes que suscribirte para usar Callsheet</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Your purchase is still pending. Please wait for it to be approved." xml:space="preserve">
@@ -1580,16 +1581,16 @@
       </trans-unit>
       <trans-unit id="Your subscription **will not** auto-renew" xml:space="preserve">
         <source>Your subscription **will not** auto-renew</source>
-        <target state="translated">Tu suscripcion **no** se renovará automaticamente</target>
+        <target state="translated">Tu suscripción **no** se renovará automaticamente</target>
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription **will** auto-renew" xml:space="preserve">
         <source>Your subscription **will** auto-renew</source>
-        <target state="translated">Tu suscripcion **si** se renovará automaticamente</target>
+        <target state="translated">Tu suscripción **si** se renovará automaticamente</target>
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription has expired; you must purchase a new subscription to use Callsheet." xml:space="preserve">
-        <source>Your subscription has expired; you must purchase a new subscription to use Callsheet.</source>
+        <source>Your subscription has expired; you must purchase a new subscription to use Callsheet.</source><target>Tu suscripción ha caducado; tienes que renovar tu suscripción para usar Callsheet</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="`%@` is unimplemented" xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -1290,7 +1290,7 @@
       </trans-unit>
       <trans-unit id="Show titles a person may be known from." xml:space="preserve">
         <source>Show titles a person may be known from.</source>
-        <target state="translated">Mostrar peliculas o series por las que una persona pueda ser conocido</target>
+        <target state="translated">Mostrar peliculas o series por las que una persona pueda ser conocida</target>
         <note/>
       </trans-unit>
       <trans-unit id="So sorry!" xml:space="preserve">
@@ -1552,7 +1552,7 @@
       </trans-unit>
       <trans-unit id="You may know them from" xml:space="preserve">
         <source>You may know them from</source>
-        <target state="translated">También conocido por</target>
+        <target state="translated">Puede que conozcas a esta persona por:</target>
         <note>Header shown for people</note>
       </trans-unit>
       <trans-unit id="You must have a subscription to use the app." xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -684,7 +684,7 @@
       </trans-unit>
       <trans-unit id="In-Credits Bonus Scenes" xml:space="preserve">
         <source>In-Credits Bonus Scenes</source>
-        <target state="translated">Escenas adicionales en créditos</target>
+        <target state="translated">Escenas adicionales (en créditos)</target>
         <note/>
       </trans-unit>
       <trans-unit id="Integrations" xml:space="preserve">
@@ -734,7 +734,7 @@
       </trans-unit>
       <trans-unit id="Mid-credits" xml:space="preserve">
         <source>Mid-credits</source>
-        <target state="translated">En medio de los créditos</target>
+        <target state="translated">En mitad de los créditos</target>
         <note/>
       </trans-unit>
       <trans-unit id="More Info…" xml:space="preserve">
@@ -1009,7 +1009,7 @@
       </trans-unit>
       <trans-unit id="Post-credits" xml:space="preserve">
         <source>Post-credits</source>
-        <target state="translated">Post créditos</target>
+        <target state="translated">Al final de los créditos</target>
         <note/>
       </trans-unit>
       <trans-unit id="Poster" xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -253,7 +253,7 @@
       </trans-unit>
       <trans-unit id="Born" xml:space="preserve">
         <source>Born</source>
-        <target state="translated">Nacido</target>
+        <target state="translated">Nacimiento</target>
         <note/>
       </trans-unit>
       <trans-unit id="Botanist" xml:space="preserve">
@@ -714,7 +714,7 @@
       </trans-unit>
       <trans-unit id="Lived" xml:space="preserve">
         <source>Lived</source>
-        <target state="translated">Vivio</target>
+        <target state="translated">Vivió</target>
         <note>How long an actor lived</note>
       </trans-unit>
       <trans-unit id="Loading…" xml:space="preserve">
@@ -789,7 +789,7 @@
       </trans-unit>
       <trans-unit id="Name or role" xml:space="preserve">
         <source>Name or role</source>
-        <target state="translated">Nombre o rol</target>
+        <target state="translated">Nombre o papel</target>
         <note>Cast search prompt</note>
       </trans-unit>
       <trans-unit id="New Episodes" xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -1552,7 +1552,7 @@
       </trans-unit>
       <trans-unit id="You may know them from" xml:space="preserve">
         <source>You may know them from</source>
-        <target state="translated">Los puedes conocer por</target>
+        <target state="translated">También conocido por</target>
         <note>Header shown for people</note>
       </trans-unit>
       <trans-unit id="You must have a subscription to use the app." xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -996,7 +996,7 @@
       </trans-unit>
       <trans-unit id="Portrait" xml:space="preserve">
         <source>Portrait</source>
-        <target state="translated">Vertical</target>
+        <target state="translated">Retrato</target>
         <note/>
       </trans-unit>
       <trans-unit id="Post-credits" xml:space="preserve">

--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -17,7 +17,7 @@
       </trans-unit>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>If Callsheet can use your local network, it may be able to show links to what you're currently watching on the main screen. Enabling local network usage is completely optional. No data about your network is sent off your device.</source>
-        <target>Si Callsheet puede usar tu red local, puede que pueda mostrar links a lo que estas viendo en este momento en tu pantalla principal. Permtir el acceso a tu red local es totalmente opcional. Ningún dato de tu red saldrá de tu dispositivo.</target>
+        <target>Si Callsheet puede usar tu red local, es posible que pueda mostrar links a lo que estas viendo en este momento en tu pantalla principal. Permitir el acceso a tu red local es totalmente opcional. Ningún dato de tu configuración de red saldrá de tu dispositivo.</target>
         <note>Privacy - Local Network Usage Description</note>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
@@ -929,12 +929,12 @@
       </trans-unit>
       <trans-unit id="Parental Guidance" xml:space="preserve">
         <source>Parental Guidance</source>
-        <target state="translated">Guía Parental</target>
+        <target state="translated">Guía para padres</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Parental guidance won't be shown for cast and crew." xml:space="preserve">
         <source>Parental guidance won't be shown for cast and crew.</source>
-        <target state="translated">La Guía Parental no se mostrará para el reparto y equipo.</target>
+        <target state="translated">La guía para padres no se mostrará para el reparto y equipo.</target>
         <note>Shown in Quick Access settings when the user selects Parental Guidance as their Quick Access button</note>
       </trans-unit>
       <trans-unit id="Persnickety Preferences" xml:space="preserve">
@@ -1077,7 +1077,7 @@
       </trans-unit>
       <trans-unit id="Quickly place emoji on photos — for privacy or fun!" xml:space="preserve">
         <source>Quickly place emoji on photos — for privacy or fun!</source>
-        <target state="translated">Pon emojis en fotos — Por privacidad o por diversión</target>
+        <target state="translated">Pon emojis en fotos rapidamente — Por privacidad o por diversión</target>
         <note>MaskerAid subtitle in Settings</note>
       </trans-unit>
       <trans-unit id="Rate this version of Callsheet" xml:space="preserve">
@@ -1364,7 +1364,7 @@
       </trans-unit>
       <trans-unit id="Technical Details" xml:space="preserve">
         <source>Technical Details</source>
-        <target state="translated">Detalles técnicos</target>
+        <target state="translated">Especificaciones técnicas</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Terms of Service" xml:space="preserve">
@@ -1424,12 +1424,12 @@
       </trans-unit>
       <trans-unit id="Trivia" xml:space="preserve">
         <source>Trivia</source>
-        <target state="translated">Cosas curiosas</target>
+        <target state="translated">Curiosidades</target>
         <note>Quick access link</note>
       </trans-unit>
       <trans-unit id="Unfortunately, [The Movie Database](https://www.themoviedb.org/) does not yet support doing a union search for shows. I've asked them to add it; we'll see what happens!" xml:space="preserve">
         <source>Unfortunately, [The Movie Database](https://www.themoviedb.org/) does not yet support doing a union search for shows. I've asked them to add it; we'll see what happens!</source>
-        <target state="translated">Desafortunadamente, [The Movie Database](https://www.themoviedb.org/) no soporta hacer uniones de busquedas para las series. Les he pedido que lo añadan, ¿veremos lo que pasa!</target>
+        <target state="translated">Desafortunadamente, [The Movie Database](https://www.themoviedb.org/) no soporta hacer uniones de busquedas para las series. Les he pedido que lo añadan, ¡veremos lo que pasa!</target>
         <note/>
       </trans-unit>
       <trans-unit id="Unknown" xml:space="preserve">
@@ -1489,7 +1489,7 @@
       </trans-unit>
       <trans-unit id="Which quick access link is shown." xml:space="preserve">
         <source>Which quick access link is shown.</source>
-        <target state="translated">Que enlace rápido se muestra de forma principal</target>
+        <target state="translated">Qué enlace rápido se muestra por defecto</target>
         <note>Shown as a subtitle for a row on Settings</note>
       </trans-unit>
       <trans-unit id="Why not shows?" xml:space="preserve">


### PR DESCRIPTION
Besides the first corrections to the settings screens I found some strings that are still in English


Spoiler settings
------
* Botanist should be localized
* Apple Keynote (episode name) should be localized


Settings
-------

Dont know if its a Test Flight Issue  but:

* Purchase a subscription
* Restore Purchases
* Force Purchase 

are not localized



About Callsheet
--------------

The only localized part is about Cassey Liss
 Erin, Declan, Mikaela.... ATP listeners is not localized



Email Feedback
--------------

In the log.txt that is sent with the email, the line

21/05/2024 07:39:45 ℹ️ [UserSettings]      ⚙️ Credits shown now set to Películas y series

Películas y series is localized. Since its a log, I think it would be easier for you not to localied that  so you can troubleshoot it better. If its localized in Korean you will have something like 프로그램



