### PR TITLE
German: Changed IAP names for Yearly and Monthly

### DIFF
--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -676,7 +676,7 @@
       </trans-unit>
       <trans-unit id="In-Credits Bonus Scenes" xml:space="preserve">
         <source>In-Credits Bonus Scenes</source>
-        <target state="translated">Bonus Szene während des Abspanns</target>
+        <target state="translated">Bonus-Szene während des Abspanns</target>
         <note/>
       </trans-unit>
       <trans-unit id="Integrations" xml:space="preserve">

--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -208,7 +208,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Apple Keynote" xml:space="preserve">
-        <source>Apple Keynote</source>
+        <source>Apple Keynote</source><target>Apple Keynote</target>
         <note>Example episode name shown in Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Are you sure?" xml:space="preserve">
@@ -257,7 +257,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Botanist" xml:space="preserve">
-        <source>Botanist</source>
+        <source>Botanist</source><target>Botaniker</target>
         <note>Example role shown in Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Browser" xml:space="preserve">
@@ -1053,7 +1053,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="Purchase a subscription" xml:space="preserve">
-        <source>Purchase a subscription</source>
+        <source>Purchase a subscription</source><target>Abonnement erwerben</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Purchased" xml:space="preserve">
@@ -1062,7 +1062,7 @@
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Purchasing is unavailable at this time." xml:space="preserve">
-        <source>Purchasing is unavailable at this time.</source>
+        <source>Purchasing is unavailable at this time.</source><target>Der Kauf ist im Moment nicht verfügbar.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Purchasing…" xml:space="preserve">
@@ -1141,11 +1141,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="Restore Purchases" xml:space="preserve">
-        <source>Restore Purchases</source>
+        <source>Restore Purchases</source><target>Käufe wiederherstellen</target>
         <note>Button title in Settings</note>
       </trans-unit>
       <trans-unit id="Restoring…" xml:space="preserve">
-        <source>Restoring…</source>
+        <source>Restoring…</source><target>Wiederherstellung läuft ...</target>
         <note>Button title in Settings when actively restoring a purchase</note>
       </trans-unit>
       <trans-unit id="Reverse sort order" xml:space="preserve">
@@ -1294,7 +1294,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="So sorry!" xml:space="preserve">
-        <source>So sorry!</source>
+        <source>So sorry!</source><target>Es tut mir sehr leid!</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Sorry, there was a problem." xml:space="preserve">
@@ -1538,11 +1538,11 @@
         <note/>
       </trans-unit>
       <trans-unit id="You have %lld day remaining in your trial.|==|plural.one" xml:space="preserve">
-        <source>You have %lld day remaining in your trial.</source>
+        <source>You have %lld day remaining in your trial.</source><target>Dein Probeabo läuft noch %lld Tag.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="You have %lld day remaining in your trial.|==|plural.other" xml:space="preserve">
-        <source>You have %lld days remaining in your trial.</source>
+        <source>You have %lld days remaining in your trial.</source><target>Dein Probeabo läuft noch %lld Tage.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="You have used all your free searches. Subscribe for unlimited searches." xml:space="preserve">
@@ -1556,12 +1556,13 @@
         <note>Header shown for people</note>
       </trans-unit>
       <trans-unit id="You must have a subscription to use the app." xml:space="preserve">
-        <source>You must have a subscription to use the app.</source>
+        <source>You must have a subscription to use the app.</source><target>Du brauchst ein Abo, um die App zu benutzen.</target>
         <note>Shown in Settings as a subtitle if you haven't purchased the app</note>
       </trans-unit>
       <trans-unit id="Your %@ will expire on&#10;%@" xml:space="preserve">
         <source>Your %1$@ will expire on
-%2$@</source>
+%2$@</source><target>Dein %1$@ läuft ab am
+%2$@</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Your favorite characters finally get married." xml:space="preserve">
@@ -1570,7 +1571,7 @@
         <note>A fake summary shown when demonstrating hiding spoilers</note>
       </trans-unit>
       <trans-unit id="Your free trial has expired; you must purchase a subscription to use Callsheet." xml:space="preserve">
-        <source>Your free trial has expired; you must purchase a subscription to use Callsheet.</source>
+        <source>Your free trial has expired; you must purchase a subscription to use Callsheet.</source><target>Dein Probeabo ist abgelaufen; du musst ein Abo abschließen, um Callsheet zu nutzen.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Your purchase is still pending. Please wait for it to be approved." xml:space="preserve">
@@ -1589,7 +1590,7 @@
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription has expired; you must purchase a new subscription to use Callsheet." xml:space="preserve">
-        <source>Your subscription has expired; you must purchase a new subscription to use Callsheet.</source>
+        <source>Your subscription has expired; you must purchase a new subscription to use Callsheet.</source><target>Dein Probeabo ist abgelaufen; du musst ein neues Abo abschließen, um Callsheet zu nutzen.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="`%@` is unimplemented" xml:space="preserve">

--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -384,7 +384,7 @@
       </trans-unit>
       <trans-unit id="Credits" xml:space="preserve">
         <source>Credits</source>
-        <target state="translated">Credits</target>
+        <target state="translated">Credit-Szene</target>
         <note>Shown as a header on the movie view for the mid- and post-credits scene icons</note>
       </trans-unit>
       <trans-unit id="Credits Lists" xml:space="preserve">

--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -676,7 +676,7 @@
       </trans-unit>
       <trans-unit id="In-Credits Bonus Scenes" xml:space="preserve">
         <source>In-Credits Bonus Scenes</source>
-        <target state="translated">Bonus-Szene während des Abspanns</target>
+        <target state="translated">Bonus-Szenen im Abspann</target>
         <note/>
       </trans-unit>
       <trans-unit id="Integrations" xml:space="preserve">

--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -384,7 +384,7 @@
       </trans-unit>
       <trans-unit id="Credits" xml:space="preserve">
         <source>Credits</source>
-        <target state="translated">Credit-Szene</target>
+        <target state="translated">Credits-Szene</target>
         <note>Shown as a header on the movie view for the mid- and post-credits scene icons</note>
       </trans-unit>
       <trans-unit id="Credits Lists" xml:space="preserve">

--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -631,7 +631,7 @@
       </trans-unit>
       <trans-unit id="IAP: Monthly Display Name" xml:space="preserve">
         <source>Monthly</source>
-        <target state="translated">Monatlich</target>
+        <target state="translated">Monats-Abo</target>
         <note>Name of the monthly subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Description" xml:space="preserve">
@@ -641,7 +641,7 @@
       </trans-unit>
       <trans-unit id="IAP: Yearly Display Name" xml:space="preserve">
         <source>Yearly Subscription</source>
-        <target state="translated">Jährlich</target>
+        <target state="translated">Jahres-Abo</target>
         <note>Name of the annual subscription in-app purchase</note>
       </trans-unit>
       <trans-unit id="IAP: Yearly Max Display Name" xml:space="preserve">

--- a/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
+++ b/CallsheetLocalizations/de.xcloc/Localized Contents/de.xliff
@@ -208,7 +208,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="Apple Keynote" xml:space="preserve">
-        <source>Apple Keynote</source><target>Apple Keynote</target>
+        <source>Apple Keynote</source>
+        <target state="translated">Apple Keynote</target>
         <note>Example episode name shown in Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Are you sure?" xml:space="preserve">
@@ -257,7 +258,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="Botanist" xml:space="preserve">
-        <source>Botanist</source><target>Botaniker</target>
+        <source>Botanist</source>
+        <target state="translated">Botaniker</target>
         <note>Example role shown in Spoiler Settings</note>
       </trans-unit>
       <trans-unit id="Browser" xml:space="preserve">
@@ -1053,7 +1055,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="Purchase a subscription" xml:space="preserve">
-        <source>Purchase a subscription</source><target>Abonnement erwerben</target>
+        <source>Purchase a subscription</source>
+        <target state="translated">Abonnement erwerben</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Purchased" xml:space="preserve">
@@ -1062,7 +1065,8 @@
         <note>Shown in a semi-hidden debugging view</note>
       </trans-unit>
       <trans-unit id="Purchasing is unavailable at this time." xml:space="preserve">
-        <source>Purchasing is unavailable at this time.</source><target>Der Kauf ist im Moment nicht verfügbar.</target>
+        <source>Purchasing is unavailable at this time.</source>
+        <target state="translated">Der Kauf ist im Moment nicht verfügbar.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Purchasing…" xml:space="preserve">
@@ -1141,11 +1145,13 @@
         <note/>
       </trans-unit>
       <trans-unit id="Restore Purchases" xml:space="preserve">
-        <source>Restore Purchases</source><target>Käufe wiederherstellen</target>
+        <source>Restore Purchases</source>
+        <target state="translated">Käufe wiederherstellen</target>
         <note>Button title in Settings</note>
       </trans-unit>
       <trans-unit id="Restoring…" xml:space="preserve">
-        <source>Restoring…</source><target>Wiederherstellung läuft ...</target>
+        <source>Restoring…</source>
+        <target state="translated">Wiederherstellung läuft ...</target>
         <note>Button title in Settings when actively restoring a purchase</note>
       </trans-unit>
       <trans-unit id="Reverse sort order" xml:space="preserve">
@@ -1294,7 +1300,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="So sorry!" xml:space="preserve">
-        <source>So sorry!</source><target>Es tut mir sehr leid!</target>
+        <source>So sorry!</source>
+        <target state="translated">Es tut mir sehr leid!</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Sorry, there was a problem." xml:space="preserve">
@@ -1538,11 +1545,13 @@
         <note/>
       </trans-unit>
       <trans-unit id="You have %lld day remaining in your trial.|==|plural.one" xml:space="preserve">
-        <source>You have %lld day remaining in your trial.</source><target>Dein Probeabo läuft noch %lld Tag.</target>
+        <source>You have %lld day remaining in your trial.</source>
+        <target state="translated">Dein Probeabo läuft noch %lld Tag.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="You have %lld day remaining in your trial.|==|plural.other" xml:space="preserve">
-        <source>You have %lld days remaining in your trial.</source><target>Dein Probeabo läuft noch %lld Tage.</target>
+        <source>You have %lld days remaining in your trial.</source>
+        <target state="translated">Dein Probeabo läuft noch %lld Tage.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="You have used all your free searches. Subscribe for unlimited searches." xml:space="preserve">
@@ -1556,12 +1565,14 @@
         <note>Header shown for people</note>
       </trans-unit>
       <trans-unit id="You must have a subscription to use the app." xml:space="preserve">
-        <source>You must have a subscription to use the app.</source><target>Du brauchst ein Abo, um die App zu benutzen.</target>
+        <source>You must have a subscription to use the app.</source>
+        <target state="translated">Du brauchst ein Abo, um die App zu benutzen.</target>
         <note>Shown in Settings as a subtitle if you haven't purchased the app</note>
       </trans-unit>
       <trans-unit id="Your %@ will expire on&#10;%@" xml:space="preserve">
         <source>Your %1$@ will expire on
-%2$@</source><target>Dein %1$@ läuft ab am
+%2$@</source>
+        <target state="translated">Dein %1$@ läuft ab am
 %2$@</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
@@ -1571,7 +1582,8 @@
         <note>A fake summary shown when demonstrating hiding spoilers</note>
       </trans-unit>
       <trans-unit id="Your free trial has expired; you must purchase a subscription to use Callsheet." xml:space="preserve">
-        <source>Your free trial has expired; you must purchase a subscription to use Callsheet.</source><target>Dein Probeabo ist abgelaufen; du musst ein Abo abschließen, um Callsheet zu nutzen.</target>
+        <source>Your free trial has expired; you must purchase a subscription to use Callsheet.</source>
+        <target state="translated">Dein Probeabo ist abgelaufen; du musst ein Abo abschließen, um Callsheet zu nutzen.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="Your purchase is still pending. Please wait for it to be approved." xml:space="preserve">
@@ -1590,7 +1602,8 @@
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription has expired; you must purchase a new subscription to use Callsheet." xml:space="preserve">
-        <source>Your subscription has expired; you must purchase a new subscription to use Callsheet.</source><target>Dein Probeabo ist abgelaufen; du musst ein neues Abo abschließen, um Callsheet zu nutzen.</target>
+        <source>Your subscription has expired; you must purchase a new subscription to use Callsheet.</source>
+        <target state="translated">Dein Probeabo ist abgelaufen; du musst ein neues Abo abschließen, um Callsheet zu nutzen.</target>
         <note>Shown on the "Purchase now" row in Settings if purchasing is unavailable</note>
       </trans-unit>
       <trans-unit id="`%@` is unimplemented" xml:space="preserve">

--- a/CallsheetLocalizations/it.xcloc/Localized Contents/it.xliff
+++ b/CallsheetLocalizations/it.xcloc/Localized Contents/it.xliff
@@ -70,7 +70,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="%@ by %@" xml:space="preserve">
-        <source>%1$@ by %2$@</source>
+        <source>%1$@ by %2$@</source><target>%1$@ realizzata da %2$@</target>
         <note>{Icon name} by {Icon artist}</note>
       </trans-unit>
       <trans-unit id="%lld" xml:space="preserve">
@@ -100,12 +100,12 @@
       </trans-unit>
       <trans-unit id="%lld free search remaining|==|plural.one" xml:space="preserve">
         <source>%lld free search remaining</source>
-        <target state="new">%lld free search remaining</target>
+        <target state="new">%lld ricerca gratis rimasta</target>
         <note>Shown on the main/bottom bar when the user has fewer than 10 of their free searches left</note>
       </trans-unit>
       <trans-unit id="%lld free search remaining|==|plural.other" xml:space="preserve">
         <source>%lld free searches remaining</source>
-        <target state="new">%lld free searches remaining</target>
+        <target state="new">%lld ricerche gratis rimaste</target>
         <note>Shown on the main/bottom bar when the user has fewer than 10 of their free searches left</note>
       </trans-unit>
       <trans-unit id="%lld minutes|==|plural.one" xml:space="preserve">
@@ -119,7 +119,7 @@
         <note/>
       </trans-unit>
       <trans-unit id="%lld of %lld" xml:space="preserve">
-        <source>%1$lld of %2$lld</source>
+        <source>%1$lld of %2$lld</source><target>%1$lld di %2$lld</target>
         <note/>
       </trans-unit>
       <trans-unit id="%lld year old|==|plural.one" xml:space="preserve">
@@ -1569,11 +1569,11 @@
         <note>Do not translate</note>
       </trans-unit>
       <trans-unit id="🤝" xml:space="preserve">
-        <source>🤝</source>
+        <source>🤝</source><target>🤝</target>
         <note/>
       </trans-unit>
       <trans-unit id="🤷‍♂️" xml:space="preserve">
-        <source>🤷‍♂️</source>
+        <source>🤷‍♂️</source><target>🤷‍♂️</target>
         <note/>
       </trans-unit>
     </body>


### PR DESCRIPTION
I amended the IAP names, as I assume they could be used in "XYZ is expiring on ABC" e.g. A noun works better in this context (as is the case with the English `source` for Yearly Subscription now, anyway).