### PR TITLE
Persnickety translation

### DIFF
--- a/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
@@ -959,12 +959,12 @@
       </trans-unit>
       <trans-unit id="Persnickety Preferences" xml:space="preserve">
         <source>Persnickety Preferences</source>
-        <target state="translated">Paramètres perspicaces</target>
+        <target state="translated">Paramètres pointilleuses</target>
         <note/>
       </trans-unit>
       <trans-unit id="Persnickety Prefs" xml:space="preserve">
         <source>Persnickety Prefs</source>
-        <target state="translated">Paramètres Perspicaces</target>
+        <target state="translated">Paramètres Pointilleuses</target>
         <note>Navigation title for Persnickety Preferences in Settings</note>
       </trans-unit>
       <trans-unit id="Pick a country" xml:space="preserve">


### PR DESCRIPTION
I think this translation is a bit better. I get "Insightful settings" or "Meaningful settings" for the current one (which is not too bad). You do get this in some translations if you type "persnickety" in English, but I don't think this translation is quite right.

This one with "pointilleuses" is translated variously as "finicky settings", "fussy parameters", "fine-tuned parameters", and "meticulous settings". Literally, it's "pointed", but it means like pressing a tiny button or twisting a little dial.

@SamTheGeek ok with you?

No need to put me in the authors on the README for one word.