### PR TITLE
Ukrainian: more consistent translation for "App Language"

### DIFF
--- a/CallsheetLocalizations/uk.xcloc/Localized Contents/uk.xliff
+++ b/CallsheetLocalizations/uk.xcloc/Localized Contents/uk.xliff
@@ -284,7 +284,7 @@
       </trans-unit>
       <trans-unit id="App Language" xml:space="preserve">
         <source>App Language</source>
-        <target state="translated">Мова</target>
+        <target state="translated">Мова інтерфейсу</target>
         <note>Title for the row in settings that allows you to set the app's language</note>
       </trans-unit>
       <trans-unit id="Apple Keynote" xml:space="preserve">
@@ -399,7 +399,7 @@
       </trans-unit>
       <trans-unit id="Change what language Callsheet itself uses" xml:space="preserve">
         <source>Change what language Callsheet itself uses</source>
-        <target state="translated">Змінити мову інтерфейсу Callsheet</target>
+        <target state="translated">Для написів та кнопок у програмі.</target>
         <note>Description for the row in settings that allows you to set the app's language</note>
       </trans-unit>
       <trans-unit id="Choose New Subscription" xml:space="preserve">


### PR DESCRIPTION
- "Мова" ("language") was not distinctive enough from "Language Override", so added "інтерфейсу" ("Language of the interface")
- The new description ("For labels and buttons in the app.") is more aligned with descriptions for Region/Language Overrides