### PR TITLE
Kinds of Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ As of [e5d60f8](https://github.com/cliss/callsheet-localizations/commit/e5d60f8a
 | Italian         | 100% :tada: | ✔️              | [cdf1982](https://github.com/cdf1982) |
 | Norwegian (Bokmål) | 100% :tada: | ✔️              | [lognseth](https://github.com/lognseth) |
 | Russian         | 100% :tada: | ✔️              | [gkeep](https://github.com/gkeep) |
-| Spanish         | 100% :tada: | ✔️              | [unaiherran](https://github.com/unaiherran) |
-| Spanish (🇲🇽)    | 100% :tada: |                 | [ccavazos](https://github.com/ccavazos |
+| Spanish (🇪🇸)    | 100% :tada: | ✔️              | [unaiherran](https://github.com/unaiherran) |
+| Spanish (🇲🇽)    | 100% :tada: |                 | [ccavazos](https://github.com/ccavazos) |
+<!---
+Spanish (419) (🌎)
+Spanish (AR/UY) (🇦🇷/🇺🇾) 
+--->
 | Swedish         | 100% :tada: | ✔️              | [sebdanielsson](https://github.com/sebdanielsson) |
 | Ukrainian       | 100% :tada: | ✔️              | [zemlanin](https://github.com/zemlanin), [buzbohdan](https://github.com/buzbohdan) |
 | Polish          | 98%         |                 | [spitfire](https://github.com/spitfire), [DonSqueak](https://github.com/donsqueak) |

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ As of [e5d60f8](https://github.com/cliss/callsheet-localizations/commit/e5d60f8a
 | Russian         | 100% :tada: | ✔️              | [gkeep](https://github.com/gkeep) |
 | Spanish (🇪🇸)    | 100% :tada: | ✔️              | [unaiherran](https://github.com/unaiherran) |
 | Spanish (🇲🇽)    | 100% :tada: |                 | [ccavazos](https://github.com/ccavazos) |
-<!---
-Spanish (419) (🌎)
-Spanish (AR/UY) (🇦🇷/🇺🇾) 
---->
 | Swedish         | 100% :tada: | ✔️              | [sebdanielsson](https://github.com/sebdanielsson) |
 | Ukrainian       | 100% :tada: | ✔️              | [zemlanin](https://github.com/zemlanin), [buzbohdan](https://github.com/buzbohdan) |
 | Polish          | 98%         |                 | [spitfire](https://github.com/spitfire), [DonSqueak](https://github.com/donsqueak) |
@@ -36,6 +32,11 @@ Spanish (AR/UY) (🇦🇷/🇺🇾)
 | Portuguese (🇧🇷) | 73%         |                 | [insidegui](https://github.com/insidegui) |
 | Japanese        | 45%         |                 | [kenroy](https://github.com/kenroy), [jaddkeita](https://github.com/jaddkeita) |
 | Danish          | 6%          |                 | [hanse00](https://github.com/hanse00) |
+
+<!---
+Spanish (419) (🌎)
+Spanish (AR/UY) (🇦🇷/🇺🇾) 
+--->
 
 [as]: https://github.com/cliss/callsheet-localizations/tree/main/AppStore
 


### PR DESCRIPTION
I noticed the Spanish flag could be in there (similar to Portuguese), and a missing closing paren on es-MX.

I left a comment on how to do es-419 and Argentina/Uruguay if you get there.

es-419 is 🌎 "Globe Showing Americas"

and

es-AR / es-UY are "🇦🇷/🇺🇾"

Just bothered because I thought "hmm, how would I represent es-419?" Change whatever you want, I just thought it would be easier to have those things in a comment rather than think "where is that PR?"
