### PR TITLE
Fr updates

### DIFF
--- a/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
@@ -1627,12 +1627,12 @@
       </trans-unit>
       <trans-unit id="Your subscription **will not** auto-renew" xml:space="preserve">
         <source>Your subscription **will not** auto-renew</source>
-        <target state="translated">Votre souscription **ne se renouvellera pas** automatiquement</target>
+        <target state="translated">Votre abonnement **ne se renouvellera pas** automatiquement</target>
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription **will** auto-renew" xml:space="preserve">
         <source>Your subscription **will** auto-renew</source>
-        <target state="translated">Votre souscription **se renouvellera** automatiquement</target>
+        <target state="translated">Votre abonnement **se renouvellera** automatiquement</target>
         <note>Only shown on a semi-hidden debugging screen</note>
       </trans-unit>
       <trans-unit id="Your subscription has expired; you must purchase a new subscription to use Callsheet." xml:space="preserve">

--- a/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
@@ -214,6 +214,7 @@
       </trans-unit>
       <trans-unit id="App Language" xml:space="preserve">
         <source>App Language</source>
+        <target state="translated">Langue de l'application</target>
         <note>Title for the row in settings that allows you to set the app's language</note>
       </trans-unit>
       <trans-unit id="Apple Keynote" xml:space="preserve">
@@ -223,6 +224,7 @@
       </trans-unit>
       <trans-unit id="Apple couldn't charge you for your subscription renewal. You will need to fix your payment and re-subscribe to continue to use Callsheet." xml:space="preserve">
         <source>Apple couldn't charge you for your subscription renewal. You will need to fix your payment and re-subscribe to continue to use Callsheet.</source>
+        <target state="translated">Apple ne pouvait pas vous facturer le renouvellement de votre abonnement. Vous devrez corriger votre paiement et vous réabonner pour continuer à utiliser Callsheet.</target>
         <note>Shown in the subscription status screen @ callsheet://subs</note>
       </trans-unit>
       <trans-unit id="Are you sure?" xml:space="preserve">
@@ -327,6 +329,7 @@
       </trans-unit>
       <trans-unit id="Change what language Callsheet itself uses" xml:space="preserve">
         <source>Change what language Callsheet itself uses</source>
+        <target state="translated">Changer la langue utilisée par Callsheet</target>
         <note>Description for the row in settings that allows you to set the app's language</note>
       </trans-unit>
       <trans-unit id="Choose New Subscription" xml:space="preserve">
@@ -1003,6 +1006,7 @@
       </trans-unit>
       <trans-unit id="Please fix your billing issue as soon as possible using the App Store app in order to keep using Callsheet." xml:space="preserve">
         <source>Please fix your billing issue as soon as possible using the App Store app in order to keep using Callsheet.</source>
+        <target state="translated">Veuillez résoudre votre problème de abonnemont dès que possible à l'aide de l'application App Store afin de continuer à utiliser Callsheet.</target>
         <note>Shown in the subscription status screen @ callsheet://subs</note>
       </trans-unit>
       <trans-unit id="Please send feedback to `hello@limitliss.co`" xml:space="preserve">
@@ -1603,6 +1607,7 @@
       </trans-unit>
       <trans-unit id="Your access to Callsheet will end on %@." xml:space="preserve">
         <source>Your access to Callsheet will end on %@.</source>
+        <target state="translated">Votre accès à Callsheet prendra fin le %@.</target>
         <note>Shown in the subscription status screen @ callsheet://subs</note>
       </trans-unit>
       <trans-unit id="Your favorite characters finally get married." xml:space="preserve">
@@ -1637,10 +1642,12 @@
       </trans-unit>
       <trans-unit id="Your subscription lapsed. To continue using Callsheet, you'll need to start a new subscription." xml:space="preserve">
         <source>Your subscription lapsed. To continue using Callsheet, you'll need to start a new subscription.</source>
+        <target state="translated">Votre abonnement est expiré. Pour continuer à utiliser Callsheet, vous devrez souscrire un nouvel abonnement.</target>
         <note>Shown in the subscription status screen @ callsheet://subs</note>
       </trans-unit>
       <trans-unit id="Your subscription was refunded or otherwise revoked. To continue using Callsheet, you'll need to start a new subscription." xml:space="preserve">
         <source>Your subscription was refunded or otherwise revoked. To continue using Callsheet, you'll need to start a new subscription.</source>
+        <target state="translated">Your subscription was refunded or otherwise revoked. To continue using Callsheet, you'll need to start a new subscription.</target>
         <note>Shown in the subscription status screen @ callsheet://subs</note>
       </trans-unit>
       <trans-unit id="per %@" xml:space="preserve">

--- a/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
@@ -1647,7 +1647,7 @@
       </trans-unit>
       <trans-unit id="Your subscription was refunded or otherwise revoked. To continue using Callsheet, you'll need to start a new subscription." xml:space="preserve">
         <source>Your subscription was refunded or otherwise revoked. To continue using Callsheet, you'll need to start a new subscription.</source>
-        <target state="translated">Your subscription was refunded or otherwise revoked. To continue using Callsheet, you'll need to start a new subscription.</target>
+        <target state="translated">Votre abonnement a été remboursé ou résilié. Pour continuer à utiliser Callsheet, vous devrez souscrire un nouvel abonnement.</target>
         <note>Shown in the subscription status screen @ callsheet://subs</note>
       </trans-unit>
       <trans-unit id="per %@" xml:space="preserve">


### PR DESCRIPTION
Hi,

[EricEEEEE](https://github.com/EricEEEEE), [samthegeek](https://github.com/samthegeek), [DonSqueak](https://github.com/donsqueak)

I updated the French and used "abonnement" everywhere for "subscription". I also dropped "Callsheet itself", since you have to write "il-même" or "elle-même" for that one. It just says "for Callsheet". Feel free to correct and improve. I speak French pretty well, but I learned it before Internet words.

My read is that "souscription" works as a verb, like "undersigned" in English. But the noun is "abonnement".