### PR TITLE
Change dark mode translation for es-ES

### DIFF
--- a/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
+++ b/CallsheetLocalizations/es.xcloc/Localized Contents/es.xliff
@@ -434,7 +434,7 @@
       </trans-unit>
       <trans-unit id="Dark" xml:space="preserve">
         <source>Dark</source>
-        <target state="translated">Obscuro</target>
+        <target state="translated">Oscuro</target>
         <note>Dark theme (other options are "light" and "system")</note>
       </trans-unit>
       <trans-unit id="Data provided by The Movie Database" xml:space="preserve">


### PR DESCRIPTION
"Dark" mode is "Obscuro" in es-419 and es-MX, but "Oscuro" in es-ES. see #130 