### PR TITLE
Change the light mode translation to match iOS in FR

### DIFF
--- a/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
@@ -746,7 +746,7 @@
       </trans-unit>
       <trans-unit id="Light" xml:space="preserve">
         <source>Light</source>
-        <target state="translated">Lumière</target>
+        <target state="translated">Claire</target>
         <note>Light theme (other options are "system" and "dark")</note>
       </trans-unit>
       <trans-unit id="Lived" xml:space="preserve">


### PR DESCRIPTION
This is how the iOS settings translate it, see #134. CC: [EricEEEEE](https://github.com/EricEEEEE), [samthegeek](https://github.com/samthegeek), [DonSqueak](https://github.com/donsqueak)