### PR TITLE
Subscription text - FR

### DIFF
--- a/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/CallsheetLocalizations/fr.xcloc/Localized Contents/fr.xliff
@@ -1621,7 +1621,7 @@
       </trans-unit>
       <trans-unit id="You must have a subscription to use the app." xml:space="preserve">
         <source>You must have a subscription to use the app.</source>
-        <target state="translated">Un abonnement est nécessaire pour utiliser l'app.</target>
+        <target state="translated">Il faut s'abonner pour utiliser l'app</target>
         <note>Shown in Settings as a subtitle if you haven't purchased the app</note>
       </trans-unit>
       <trans-unit id="Your %@ will expire on&#10;%@" xml:space="preserve">


### PR DESCRIPTION
I went and looked at this, per https://mastodon.social/@sayrer/112956689291988459

I asked my folks, who both speak FR much better than I do, far past fluent. One said mine was nicer (closer to "you gotta do this..."), and one said it didn't matter. I think it's nicer my way "that's the way it is" vs "you must do something...", but that's the difference.

When I went to do the patch, I noticed the English is "You must have a subscription to use the app." The current French matches that exactly and maybe more nicely (no "you"), but I think the tone of the English is more harsh than you usually write, so maybe that's a bug. Obv up to you.