### PR TITLE
The translation for 'years old' when deceased was wrong.

### DIFF
--- a/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
+++ b/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
@@ -186,7 +186,7 @@
       </trans-unit>
       <trans-unit id="%lld years" xml:space="preserve">
         <source>%lld years</source>
-        <target state="translated">%lld jaren</target>
+        <target state="translated">%lld jaar</target>
         <note>How old a person was when they passed</note>
       </trans-unit>
       <trans-unit id="%lld years old|==|plural.one" xml:space="preserve">


### PR DESCRIPTION
Minor update. Noticed the wrong translation when using the app.