### PR TITLE
Dutch localization updated

### DIFF
--- a/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
+++ b/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
@@ -246,7 +246,7 @@
       </trans-unit>
       <trans-unit id="Add list…" xml:space="preserve">
         <source>Add list…</source>
-        <target state="translated">Voeg lijst toe…</target>
+        <target state="translated">Lijst toevoegen…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add or Remove From Other Lists" xml:space="preserve">

--- a/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
+++ b/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
@@ -12,7 +12,7 @@
       </trans-unit>
       <trans-unit id="Open ${applicationName} pins" xml:space="preserve">
         <source>Open ${applicationName} pins</source>
-        <target>Open vastgezette items in ${applicationName}</target>
+        <target>Open vastgemaakte items in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Open ${applicationName} recent search" xml:space="preserve">
@@ -256,7 +256,7 @@
       </trans-unit>
       <trans-unit id="Add pin" xml:space="preserve">
         <source>Add pin</source>
-        <target state="translated">Voeg vastgezet item toe</target>
+        <target state="translated">Voeg vastgemaakt item toe</target>
         <note/>
       </trans-unit>
       <trans-unit id="Ads" xml:space="preserve">
@@ -1001,7 +1001,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="No TV show pins found." xml:space="preserve">
         <source>No TV show pins found.</source>
-        <target state="translated">Geen vastgezette series gevonden.</target>
+        <target state="translated">Geen vastgemaakte series gevonden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No credits found." xml:space="preserve">
@@ -1016,7 +1016,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="No movie pins found." xml:space="preserve">
         <source>No movie pins found.</source>
-        <target state="translated">Geen vastgezette films gevonden.</target>
+        <target state="translated">Geen vastgemaakte films gevonden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No override" xml:space="preserve">
@@ -1036,22 +1036,22 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="No people pins found." xml:space="preserve">
         <source>No people pins found.</source>
-        <target state="translated">Geen vastgezette personen gevonden.</target>
+        <target state="translated">Geen vastgemaakte personen gevonden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No pinned items found." xml:space="preserve">
         <source>No pinned items found.</source>
-        <target state="translated">Geen vastgezette items gevonden.</target>
+        <target state="translated">Geen vastgemaakte items gevonden.</target>
         <note>Shown on the home screen</note>
       </trans-unit>
       <trans-unit id="No pins" xml:space="preserve">
         <source>No pins</source>
-        <target>Geen vastgezette items</target>
+        <target>Geen vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="No pins found." xml:space="preserve">
         <source>No pins found.</source>
-        <target>Geen vastgezette items gevonden.</target>
+        <target>Geen vastgemaakte items gevonden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No providers found." xml:space="preserve">
@@ -1096,12 +1096,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Open Pinned Items" xml:space="preserve">
         <source>Open Pinned Items</source>
-        <target>Open vastgezette items</target>
+        <target>Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open Pins" xml:space="preserve">
         <source>Open Pins</source>
-        <target>Open vastgezette items</target>
+        <target>Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open in browser" xml:space="preserve">
@@ -1111,7 +1111,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Open the list of your pinned items" xml:space="preserve">
         <source>Open the list of your pinned items</source>
-        <target>Open de lijst met jouw vastgezette items</target>
+        <target>Open de lijst met jouw vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Optionally, you can choose to help more." xml:space="preserve">
@@ -1191,22 +1191,22 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
         <source>Pinned Items</source>
-        <target state="translated">Vastgezette items</target>
+        <target state="translated">Vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pinned items" xml:space="preserve">
         <source>Pinned items</source>
-        <target state="translated">Vastgezette items</target>
+        <target state="translated">Vastgemaakte items</target>
         <note>Shown on the pre-sales screen to get users to subscribe</note>
       </trans-unit>
       <trans-unit id="Pinned items are shown at the top of the main screen when you open Callsheet. You can pin movies, shows, or people." xml:space="preserve">
         <source>Pinned items are shown at the top of the main screen when you open Callsheet. You can pin movies, shows, or people.</source>
-        <target>Vastgezette items worden getoond bovenaan het hoofdscherm als je Callsheet opent. Je kunt films, series of personen vastzetten.</target>
+        <target state="translated">Vastgemaakte items worden getoond bovenaan het hoofdscherm als je Callsheet opent. Je kunt films, series of personen vastzetten.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pins" xml:space="preserve">
         <source>Pins</source>
-        <target>Vastgezette items</target>
+        <target state="translated">Vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Plans:" xml:space="preserve">
@@ -1666,7 +1666,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="There are a total of %lld lists and %lld pins." xml:space="preserve">
         <source>There are a total of %1$lld lists and %2$lld pins.</source>
-        <target>Er zijn in totaal %1$lld lijsten en %2$lld vastgezette items.</target>
+        <target>Er zijn in totaal %1$lld lijsten en %2$lld vastgemaakte items.</target>
         <note/>
       </trans-unit>
       <trans-unit id="There is no watch information available for *%@*." xml:space="preserve">
@@ -1923,12 +1923,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="pin" xml:space="preserve">
         <source>pin</source>
-        <target state="translated">vastgezet item</target>
+        <target state="translated">vastgemaakt item</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
         <source>pinned items</source>
-        <target state="translated">Vastgezette items</target>
+        <target state="translated">Vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="visionOS does not support changing icons yet." xml:space="preserve">
@@ -1991,22 +1991,22 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Open Pinned Items" xml:space="preserve">
         <source>Open Pinned Items</source>
-        <target>Open vastgezette items</target>
+        <target>Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open Pins" xml:space="preserve">
         <source>Open Pins</source>
-        <target>Open vastgezette items</target>
+        <target>Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open the list of your pinned items" xml:space="preserve">
         <source>Open the list of your pinned items</source>
-        <target>Open de lijst met jouw vastgezette items</target>
+        <target>Open de lijst met jouw vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open your pins in Callsheet" xml:space="preserve">
         <source>Open your pins in Callsheet</source>
-        <target>Open vastgezette items in Callsheet</target>
+        <target>Open vastgemaakte items in Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Perform your most recent search in Callsheet" xml:space="preserve">
@@ -2016,12 +2016,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Pin" xml:space="preserve">
         <source>Pin</source>
-        <target>Vastgezet item</target>
+        <target state="translated">Vastgemaakt item</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
         <source>Pinned Items</source>
-        <target>Vastgezette items</target>
+        <target status="translated">Vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Recent Search" xml:space="preserve">
@@ -2056,7 +2056,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Shows one or more of your most recent pinned items" xml:space="preserve">
         <source>Shows one or more of your most recent pinned items</source>
-        <target>Toont een of meerdere van je onlangs vastgezette items</target>
+        <target state="translated">Toont een of meerdere van je onlangs vastgemaakt items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Start a new search in Callsheet" xml:space="preserve">
@@ -2081,12 +2081,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="pin" xml:space="preserve">
         <source>pin</source>
-        <target>vastgezet item</target>
+        <target target="translated">vastgemaakt item</target>
         <note>Noun, a pin/favorite</note>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
         <source>pinned items</source>
-        <target>vastgezette items</target>
+        <target>vastgemaakte items</target>
         <note/>
       </trans-unit>
     </body>

--- a/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
+++ b/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
@@ -1176,7 +1176,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Pin This Item" xml:space="preserve">
         <source>Pin This Item</source>
-        <target state="translated">Zet dit item vast</target>
+        <target state="translated">Maak dit item vast</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pin Type" xml:space="preserve">
@@ -1201,7 +1201,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Pinned items are shown at the top of the main screen when you open Callsheet. You can pin movies, shows, or people." xml:space="preserve">
         <source>Pinned items are shown at the top of the main screen when you open Callsheet. You can pin movies, shows, or people.</source>
-        <target state="translated">Vastgemaakte items worden getoond bovenaan het hoofdscherm als je Callsheet opent. Je kunt films, series of personen vastzetten.</target>
+        <target state="translated">Vastgemaakte items worden getoond bovenaan het hoofdscherm als je Callsheet opent. Je kunt films, series of personen vastmaken.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pins" xml:space="preserve">

--- a/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
+++ b/CallsheetLocalizations/nl.xcloc/Localized Contents/nl.xliff
@@ -7,52 +7,52 @@
     <body>
       <trans-unit id="Open ${applicationName} favorites" xml:space="preserve">
         <source>Open ${applicationName} favorites</source>
-        <target>Open favorieten in ${applicationName}</target>
+        <target state="translated">Open favorieten in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Open ${applicationName} pins" xml:space="preserve">
         <source>Open ${applicationName} pins</source>
-        <target>Open vastgemaakte items in ${applicationName}</target>
+        <target state="translated">Open vastgemaakte items in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Open ${applicationName} recent search" xml:space="preserve">
         <source>Open ${applicationName} recent search</source>
-        <target>Open recente zoekopdrachten in ${applicationName}</target>
+        <target state="translated">Open recente zoekopdrachten in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Open my most recent search in ${applicationName}" xml:space="preserve">
         <source>Open my most recent search in ${applicationName}</source>
-        <target>Open mijn meest recente zoekopdracht in ${applicationName}</target>
+        <target state="translated">Open mijn meest recente zoekopdracht in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Open recent search in ${applicationName}" xml:space="preserve">
         <source>Open recent search in ${applicationName}</source>
-        <target>Open recente zoekopdrachten in ${applicationName}</target>
+        <target state="translated">Open recente zoekopdrachten in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Open saved items in ${applicationName}" xml:space="preserve">
         <source>Open saved items in ${applicationName}</source>
-        <target>Open bewaarde items in ${applicationName}</target>
+        <target state="translated">Open bewaarde items in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Search ${applicationName}" xml:space="preserve">
         <source>Search ${applicationName}</source>
-        <target>Zoek ${applicationName}</target>
+        <target state="translated">Zoek ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Show ${applicationName} recent search" xml:space="preserve">
         <source>Show ${applicationName} recent search</source>
-        <target>Toon recente zoekopdrachten van ${applicationName}</target>
+        <target state="translated">Toon recente zoekopdrachten van ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Show my most recent search in ${applicationName}" xml:space="preserve">
         <source>Show my most recent search in ${applicationName}</source>
-        <target>Toon mijn meest recente zoekactie in ${applicationName}</target>
+        <target state="translated">Toon mijn meest recente zoekactie in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Show recent search in ${applicationName}" xml:space="preserve">
         <source>Show recent search in ${applicationName}</source>
-        <target>Toon recente zoekopdrachten in ${applicationName}</target>
+        <target state="translated">Toon recente zoekopdrachten in ${applicationName}</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
     </body>
@@ -64,27 +64,27 @@
     <body>
       <trans-unit id="CFBundleDisplayName" xml:space="preserve">
         <source>Callsheet</source>
-        <target>Callsheet</target>
+        <target state="translated">Callsheet</target>
         <note>Bundle display name</note>
       </trans-unit>
       <trans-unit id="CFBundleName" xml:space="preserve">
         <source>Callsheet</source>
-        <target>Callsheet</target>
+        <target state="translated">Callsheet</target>
         <note>Bundle name</note>
       </trans-unit>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>If Callsheet can use your local network, it may be able to show links to what you're currently watching on the main screen. Enabling local network usage is completely optional. No data about your network is sent off your device.</source>
-        <target>Als Callsheet je lokale network mag gebruiken kan het je links tonen naar hetgeen je momenteel naar aan het kijken bent op het hoofdscherm.Toegang verlenen tot je lokale netwerk is volkomen optioneel. Er wordt geen informatie over je netwerk buiten je apparaat gedeeld.</target>
+        <target state="translated">Als Callsheet je lokale network mag gebruiken kan het je links tonen naar hetgeen je momenteel naar aan het kijken bent op het hoofdscherm.Toegang verlenen tot je lokale netwerk is volkomen optioneel. Er wordt geen informatie over je netwerk buiten je apparaat gedeeld.</target>
         <note>Privacy - Local Network Usage Description</note>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
         <source>Search</source>
-        <target>Zoek</target>
+        <target state="translated">Zoek</target>
         <note/>
       </trans-unit>
       <trans-unit id="Title, cast, or crew" xml:space="preserve">
         <source>Title, cast, or crew</source>
-        <target>Titel, cast- of crewleden</target>
+        <target state="translated">Titel, cast- of crewleden</target>
         <note/>
       </trans-unit>
     </body>
@@ -156,7 +156,7 @@
       </trans-unit>
       <trans-unit id="%lld episode|==|plural.other" xml:space="preserve">
         <source>%lld episodes</source>
-        <target>%lld afleveringen</target>
+        <target state="translated">%lld afleveringen</target>
         <note>How many episodes a person has been appeared in for a TV show, or how many episodes are in a TV season</note>
       </trans-unit>
       <trans-unit id="%lld free search remaining|==|plural.one" xml:space="preserve">
@@ -226,7 +226,7 @@
       </trans-unit>
       <trans-unit id="Add" xml:space="preserve">
         <source>Add</source>
-        <target>Voeg toe</target>
+        <target state="translated">Voeg toe</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add %lld Free Search|==|plural.one" xml:space="preserve">
@@ -246,12 +246,12 @@
       </trans-unit>
       <trans-unit id="Add list…" xml:space="preserve">
         <source>Add list…</source>
-        <target>Voeg lijst toe…</target>
+        <target state="translated">Voeg lijst toe…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add or Remove From Other Lists" xml:space="preserve">
         <source>Add or Remove From Other Lists</source>
-        <target>Voeg toe aan of verwijder van andere lijsten</target>
+        <target state="translated">Voeg toe aan of verwijder van andere lijsten</target>
         <note/>
       </trans-unit>
       <trans-unit id="Add pin" xml:space="preserve">
@@ -311,7 +311,7 @@
       </trans-unit>
       <trans-unit id="Are You Sure?" xml:space="preserve">
         <source>Are You Sure?</source>
-        <target>Weet je het zeker?</target>
+        <target state="translated">Weet je het zeker?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Are you sure?" xml:space="preserve">
@@ -553,7 +553,7 @@
         <source>Delete the list "%1$@"?
 
 It currently has %2$lld pin.</source>
-        <target>Lijst ‘%1$@’ verwijderen?
+        <target state="translated">Lijst ‘%1$@’ verwijderen?
 
 Er staat %2$lld items op.</target>
         <note/>
@@ -562,14 +562,14 @@ Er staat %2$lld items op.</target>
         <source>Delete the list "%1$@"?
 
 It currently has %2$lld pins.</source>
-        <target>Lijst ‘%1$@’ verwijderen?
+        <target state="translated">Lijst ‘%1$@’ verwijderen?
 
 Er staan %2$lld items op.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Delete this list?" xml:space="preserve">
         <source>Delete this list?</source>
-        <target>Deze lijst verwijderen?</target>
+        <target state="translated">Deze lijst verwijderen?</target>
         <note/>
       </trans-unit>
       <trans-unit id="Details" xml:space="preserve">
@@ -691,7 +691,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Free search remaining" xml:space="preserve">
         <source>Free search remaining</source>
-        <target>Gratis zoekopdrachten over</target>
+        <target state="translated">Gratis zoekopdrachten over</target>
         <note/>
       </trans-unit>
       <trans-unit id="Free searches remaining" xml:space="preserve">
@@ -876,7 +876,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="List Name" xml:space="preserve">
         <source>List Name</source>
-        <target>Lijstnaam</target>
+        <target state="translated">Lijstnaam</target>
         <note/>
       </trans-unit>
       <trans-unit id="Lived" xml:space="preserve">
@@ -891,7 +891,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Long-Running Series" xml:space="preserve">
         <source>Long-Running Series</source>
-        <target>Langlopende series</target>
+        <target state="translated">Langlopende series</target>
         <note>Header shown on a person's credit list, for long-running series such as Saturday Night Live</note>
       </trans-unit>
       <trans-unit id="Macro State at %@" xml:space="preserve">
@@ -901,7 +901,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Manage Lists" xml:space="preserve">
         <source>Manage Lists</source>
-        <target>Lijsten beheren</target>
+        <target state="translated">Lijsten beheren</target>
         <note/>
       </trans-unit>
       <trans-unit id="Manage Subscription" xml:space="preserve">
@@ -911,7 +911,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Manage lists…" xml:space="preserve">
         <source>Manage lists…</source>
-        <target>Lijsten beheren…</target>
+        <target state="translated">Lijsten beheren…</target>
         <note/>
       </trans-unit>
       <trans-unit id="Mid-credits" xml:space="preserve">
@@ -996,7 +996,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="No" xml:space="preserve">
         <source>No</source>
-        <target>Nee</target>
+        <target state="translated">Nee</target>
         <note/>
       </trans-unit>
       <trans-unit id="No TV show pins found." xml:space="preserve">
@@ -1046,12 +1046,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="No pins" xml:space="preserve">
         <source>No pins</source>
-        <target>Geen vastgemaakte items</target>
+        <target state="translated">Geen vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="No pins found." xml:space="preserve">
         <source>No pins found.</source>
-        <target>Geen vastgemaakte items gevonden.</target>
+        <target state="translated">Geen vastgemaakte items gevonden.</target>
         <note/>
       </trans-unit>
       <trans-unit id="No providers found." xml:space="preserve">
@@ -1096,12 +1096,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Open Pinned Items" xml:space="preserve">
         <source>Open Pinned Items</source>
-        <target>Open vastgemaakte items</target>
+        <target state="translated">Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open Pins" xml:space="preserve">
         <source>Open Pins</source>
-        <target>Open vastgemaakte items</target>
+        <target state="translated">Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open in browser" xml:space="preserve">
@@ -1111,7 +1111,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Open the list of your pinned items" xml:space="preserve">
         <source>Open the list of your pinned items</source>
-        <target>Open de lijst met jouw vastgemaakte items</target>
+        <target state="translated">Open de lijst met jouw vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Optionally, you can choose to help more." xml:space="preserve">
@@ -1176,7 +1176,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Pin This Item" xml:space="preserve">
         <source>Pin This Item</source>
-        <target>Zet dit item vast</target>
+        <target state="translated">Zet dit item vast</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pin Type" xml:space="preserve">
@@ -1326,7 +1326,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Recent Search" xml:space="preserve">
         <source>Recent Search</source>
-        <target>Recente zoekopdracht</target>
+        <target state="translated">Recente zoekopdracht</target>
         <note/>
       </trans-unit>
       <trans-unit id="Recent Searches" xml:space="preserve">
@@ -1376,12 +1376,12 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Repeat Search" xml:space="preserve">
         <source>Repeat Search</source>
-        <target>Zoekopdracht herhalen</target>
+        <target state="translated">Zoekopdracht herhalen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Repeats the most recent search." xml:space="preserve">
         <source>Repeats the most recent search.</source>
-        <target>Herhaalt de meest recente zoekopdracht.</target>
+        <target state="translated">Herhaalt de meest recente zoekopdracht.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Request Refund" xml:space="preserve">
@@ -1571,7 +1571,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Starts a new Search within Callsheet." xml:space="preserve">
         <source>Starts a new Search within Callsheet.</source>
-        <target>Voer een nieuwe zoekopdracht uit binnen Callsheet.</target>
+        <target state="translated">Voer een nieuwe zoekopdracht uit binnen Callsheet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Subscribe" xml:space="preserve">
@@ -1611,7 +1611,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Switch list" xml:space="preserve">
         <source>Switch list</source>
-        <target>Wissel van lijst</target>
+        <target state="translated">Wissel van lijst</target>
         <note/>
       </trans-unit>
       <trans-unit id="System" xml:space="preserve">
@@ -1641,7 +1641,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Tap-and-hold on the pin in the toolbar to see a menu with more actions. Use this as a quick way to add or remove this item from other lists." xml:space="preserve">
         <source>Tap-and-hold on the pin in the toolbar to see a menu with more actions. Use this as a quick way to add or remove this item from other lists.</source>
-        <target>Tik en houd de punaise vast in de taakbalk voor een menu met meer opties. Gebruik dit als een snelle manier om dit item toe te voegen aan of te verwijderen van andere lijsten.</target>
+        <target state="translated">Tik en houd de punaise vast in de taakbalk voor een menu met meer opties. Gebruik dit als een snelle manier om dit item toe te voegen aan of te verwijderen van andere lijsten.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Technical Details" xml:space="preserve">
@@ -1666,7 +1666,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="There are a total of %lld lists and %lld pins." xml:space="preserve">
         <source>There are a total of %1$lld lists and %2$lld pins.</source>
-        <target>Er zijn in totaal %1$lld lijsten en %2$lld vastgemaakte items.</target>
+        <target state="translated">Er zijn in totaal %1$lld lijsten en %2$lld vastgemaakte items.</target>
         <note/>
       </trans-unit>
       <trans-unit id="There is no watch information available for *%@*." xml:space="preserve">
@@ -1816,7 +1816,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Yes" xml:space="preserve">
         <source>Yes</source>
-        <target>Ja</target>
+        <target state="translated">Ja</target>
         <note/>
       </trans-unit>
       <trans-unit id="You Can Help" xml:space="preserve">
@@ -1960,12 +1960,12 @@ Er staan %2$lld items op.</target>
     <body>
       <trans-unit id="CFBundleDisplayName" xml:space="preserve">
         <source>Widgets</source>
-        <target>Widgets</target>
+        <target state="translated">Widgets</target>
         <note>Bundle display name</note>
       </trans-unit>
       <trans-unit id="CFBundleName" xml:space="preserve">
         <source>WidgetsExtension</source>
-        <target>WidgetExtension</target>
+        <target state="translated">WidgetExtension</target>
         <note>Bundle name</note>
       </trans-unit>
       <trans-unit id="NSHumanReadableCopyright" xml:space="preserve">
@@ -1981,37 +1981,37 @@ Er staan %2$lld items op.</target>
     <body>
       <trans-unit id="Name or job in %@" xml:space="preserve">
         <source>Name or job in %@</source>
-        <target>Naam of functie in %@</target>
+        <target state="translated">Naam of functie in %@</target>
         <note>Crew search prompt; I'll replace "%@" with the name of the media in question, so for the translation, please include "%@" where appropriate.</note>
       </trans-unit>
       <trans-unit id="Name or role in %@" xml:space="preserve">
         <source>Name or role in %@</source>
-        <target>Naam of rol in %@</target>
+        <target state="translated">Naam of rol in %@</target>
         <note>Cast search prompt; I'll replace "%@" with the name of the media in question, so for the translation, please include "%@" where appropriate.</note>
       </trans-unit>
       <trans-unit id="Open Pinned Items" xml:space="preserve">
         <source>Open Pinned Items</source>
-        <target>Open vastgemaakte items</target>
+        <target state="translated">Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open Pins" xml:space="preserve">
         <source>Open Pins</source>
-        <target>Open vastgemaakte items</target>
+        <target state="translated">Open vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open the list of your pinned items" xml:space="preserve">
         <source>Open the list of your pinned items</source>
-        <target>Open de lijst met jouw vastgemaakte items</target>
+        <target state="translated">Open de lijst met jouw vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Open your pins in Callsheet" xml:space="preserve">
         <source>Open your pins in Callsheet</source>
-        <target>Open vastgemaakte items in Callsheet</target>
+        <target state="translated">Open vastgemaakte items in Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Perform your most recent search in Callsheet" xml:space="preserve">
         <source>Perform your most recent search in Callsheet</source>
-        <target>Voer de meest recente zoekactie uit in Callsheet</target>
+        <target state="translated">Voer de meest recente zoekactie uit in Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Pin" xml:space="preserve">
@@ -2021,37 +2021,37 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Pinned Items" xml:space="preserve">
         <source>Pinned Items</source>
-        <target status="translated">Vastgemaakte items</target>
+        <target state="translated">Vastgemaakte items</target>
         <note/>
       </trans-unit>
       <trans-unit id="Recent Search" xml:space="preserve">
         <source>Recent Search</source>
-        <target>Recente zoekopdracht</target>
+        <target state="translated">Recente zoekopdracht</target>
         <note/>
       </trans-unit>
       <trans-unit id="Repeat Last Search" xml:space="preserve">
         <source>Repeat Last Search</source>
-        <target>Laatste zoekopdracht herhalen</target>
+        <target state="translated">Laatste zoekopdracht herhalen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Repeat Search" xml:space="preserve">
         <source>Repeat Search</source>
-        <target>Zoekopdracht herhalen</target>
+        <target state="translated">Zoekopdracht herhalen</target>
         <note/>
       </trans-unit>
       <trans-unit id="Repeats the most recent search." xml:space="preserve">
         <source>Repeats the most recent search.</source>
-        <target>Herhaalt de meest recente zoekopdracht.</target>
+        <target state="translated">Herhaalt de meest recente zoekopdracht.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Search" xml:space="preserve">
         <source>Search</source>
-        <target>Zoek</target>
+        <target state="translated">Zoek</target>
         <note/>
       </trans-unit>
       <trans-unit id="Search Callsheet" xml:space="preserve">
         <source>Search Callsheet</source>
-        <target>Zoek in Callsheet</target>
+        <target state="translated">Zoek in Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Shows one or more of your most recent pinned items" xml:space="preserve">
@@ -2061,22 +2061,22 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="Start a new search in Callsheet" xml:space="preserve">
         <source>Start a new search in Callsheet</source>
-        <target>Voer een nieuwe zoekopdracht uit in Callsheet</target>
+        <target state="translated">Voer een nieuwe zoekopdracht uit in Callsheet</target>
         <note/>
       </trans-unit>
       <trans-unit id="Starts a new Search within Callsheet." xml:space="preserve">
         <source>Starts a new Search within Callsheet.</source>
-        <target>Voer een nieuwe zoekopdracht uit binnen Callsheet.</target>
+        <target state="translated">Voer een nieuwe zoekopdracht uit binnen Callsheet.</target>
         <note/>
       </trans-unit>
       <trans-unit id="Title or job" xml:space="preserve">
         <source>Title or job</source>
-        <target>Titel of functie</target>
+        <target state="translated">Titel of functie</target>
         <note>Crew search prompt in the context of a single person (not a movie/show/etc)</note>
       </trans-unit>
       <trans-unit id="Title or role" xml:space="preserve">
         <source>Title or role</source>
-        <target>Titel of rol</target>
+        <target state="translated">Titel of rol</target>
         <note>Cast search prompt in the context of a single person (not a movie/show/etc)</note>
       </trans-unit>
       <trans-unit id="pin" xml:space="preserve">
@@ -2086,7 +2086,7 @@ Er staan %2$lld items op.</target>
       </trans-unit>
       <trans-unit id="pinned items" xml:space="preserve">
         <source>pinned items</source>
-        <target>vastgemaakte items</target>
+        <target state="translated">vastgemaakte items</target>
         <note/>
       </trans-unit>
     </body>


### PR DESCRIPTION
I noticed that in other iOS apps, the term _vastmaken_ 'to attach, to fix, to pin, etc.' is used (instead of _vastzetten_ 'to fix, to jail'), which is a better translation, imo, _and_ it is more consistent. 

Also, I added the `state="translated"` attribute on `target` nodes that didn't have them yet.